### PR TITLE
Copy partial code blocks fixed for chrome

### DIFF
--- a/app/frontend/src/components/CodeBlockRenderer/CodeBlockRenderer.tsx
+++ b/app/frontend/src/components/CodeBlockRenderer/CodeBlockRenderer.tsx
@@ -47,7 +47,7 @@ export default function CodeBlockRenderer(props: ClassAttributes<HTMLElement> & 
                     style={ligth_theme_pref ? duotoneLight : dark}
                     language={language}
                     PreTag="div"
-                    showLineNumbers={true}
+                    showLineNumbers={false}
                     wrapLongLines={true}
                 />
                 <div className={styles.copyContainer}>


### PR DESCRIPTION

There exist a bug in **syntax-highlighter** when  _wrapLongLines_ and _showLineNumber_ is enabled :

https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/432

We will disable line numbers till it is fixed.
**Description**

Short description or comments

**Reference**

closes  #144 
