### PR TITLE
🔧 fixed token used display

### DIFF
--- a/app/frontend/src/components/QuestionInput/QuestionInput.tsx
+++ b/app/frontend/src/components/QuestionInput/QuestionInput.tsx
@@ -21,7 +21,7 @@ interface Props {
 export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend, tokens_used, token_limit_tracking = true, question, setQuestion }: Props) => {
     const { t, i18n } = useTranslation();
     const { LLM } = useContext(LLMContext);
-    const [description, setDescription] = useState<string>("0");
+    const [description, setDescription] = useState<string>("");
     const getDescription = () => {
         let actual = countWords(question) + tokens_used;
         let text;
@@ -31,7 +31,7 @@ export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend, toke
         } else text = `${actual} ${t("components.questioninput.tokensused")}`;
         return text;
     };
-    useEffect(() => setDescription(getDescription()), [tokens_used]);
+    useEffect(() => setDescription(getDescription()), [tokens_used, LLM.max_input_tokens]);
 
     const sendQuestion = () => {
         if (disabled || !question.trim()) {
@@ -78,7 +78,7 @@ export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend, toke
                 onKeyDown={onEnterPress}
             />
             <div className={styles.questionInputContainerFooter}>
-                <div>{description}</div>
+                {tokens_used == 0 ? <div>{" "}</div> : <div>{description}</div>}
                 <div className={styles.errorhint}>{t("components.questioninput.errorhint")}</div>
                 <div className={styles.questionInputButtonsContainer}>
                     <Tooltip content={placeholder || ""} relationship="label">

--- a/app/frontend/src/components/SumInput/SumInput.tsx
+++ b/app/frontend/src/components/SumInput/SumInput.tsx
@@ -12,27 +12,14 @@ interface Props {
     disabled: boolean;
     placeholder?: string;
     clearOnSend?: boolean;
-    tokens_used: number;
-    token_limit_tracking?: boolean;
     question: string;
     setQuestion: (question: string) => void;
 }
 
-export const SumInput = ({ onSend, disabled, placeholder, clearOnSend, tokens_used, token_limit_tracking = true, question, setQuestion }: Props) => {
+export const SumInput = ({ onSend, disabled, placeholder, clearOnSend, question, setQuestion }: Props) => {
     const { t, i18n } = useTranslation();
     const [dragging, setDragging] = useState(false);
     const [file, setFile] = useState<File | undefined>(undefined);
-    const { LLM } = useContext(LLMContext);
-    const wordCount = LLM.max_input_tokens;
-    const getDescription = () => {
-        let actual = countWords(question) + tokens_used;
-        let text;
-        if (token_limit_tracking) {
-            text = `${actual}/ ${wordCount} ${t("components.suminput.tokensused")}`;
-            if (actual > wordCount) text += `${t("components.suminput.limit")}`;
-        } else text = `${actual} ${t("components.suminput.tokensused")}`;
-        return text;
-    };
 
     const sendQuestion = () => {
         if (disabled || (!question.trim() && !file)) {
@@ -52,10 +39,6 @@ export const SumInput = ({ onSend, disabled, placeholder, clearOnSend, tokens_us
             sendQuestion();
         }
     };
-
-    function countWords(str: string) {
-        return str.trim().split(/\s+/).length;
-    }
 
     const onQuestionChange = (_ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: TextareaOnChangeData) => {
         if (!newValue?.value) {
@@ -112,7 +95,7 @@ export const SumInput = ({ onSend, disabled, placeholder, clearOnSend, tokens_us
                 />
             )}
             <div className={styles.questionInputContainerFooter}>
-                {file ? <div></div> : <div>{getDescription()}</div>}
+                <div></div>
                 <div className={styles.questionInputButtonsContainer}>
                     <Tooltip content={placeholder || ""} relationship="label">
                         <Button size="large" appearance="subtle" icon={<Send28Filled />} disabled={sendQuestionDisabled} onClick={sendQuestion} />

--- a/app/frontend/src/pages/summarize/Summarize.tsx
+++ b/app/frontend/src/pages/summarize/Summarize.tsx
@@ -129,8 +129,6 @@ const Summarize = () => {
             placeholder={t("sum.prompt")}
             disabled={isLoading}
             onSend={(question, file) => makeApiRequest(question, file)}
-            tokens_used={0}
-            token_limit_tracking={false}
             question={question}
             setQuestion={setQuestion}
         />


### PR DESCRIPTION
**Description**
- If no tokens are used, the description `1/XXX Tokens used` is no longer displayed for a cleaner interface.
- For the Summarize and Brainstorm features, token usage is no longer displayed.
- Fixed the bug where reloading showed `1/0 tokens used`.
