### PR TITLE
Deleted communityassistants in db

### DIFF
--- a/mucgpt-assistant-service/src/api/api_models.py
+++ b/mucgpt-assistant-service/src/api/api_models.py
@@ -494,7 +494,7 @@ class SubscriptionResponse(BaseModel):
         description="Unique identifier for the assistant (UUID v4)",
         example="123e4567-e89b-12d3-a456-426614174000",
     )
-    name: str = Field(
+    title: str = Field(
         ...,
         description="The name/title of the assistant",
         example="Technical Support Assistant",
@@ -511,7 +511,8 @@ class SubscriptionResponse(BaseModel):
         json_schema_extra={
             "example": {
                 "id": "123e4567-e89b-12d3-a456-426614174000",
-                "name": "Technical Support Assistant",
+                "title": "Technical Support Assistant",
+                "description": "An AI assistant specialized in providing technical support for software issues",
             }
         },
     )

--- a/mucgpt-assistant-service/src/api/routers/users_router.py
+++ b/mucgpt-assistant-service/src/api/routers/users_router.py
@@ -230,7 +230,7 @@ async def get_user_subscriptions(
         if latest_version:
             response = SubscriptionResponse(
                 id=assistant_id,
-                name=getattr(latest_version, "name", ""),
+                title=getattr(latest_version, "name", ""),
                 description=getattr(latest_version, "description", ""),
             )
             response_list.append(response)

--- a/mucgpt-assistant-service/src/database/assistant_repo.py
+++ b/mucgpt-assistant-service/src/database/assistant_repo.py
@@ -1,7 +1,7 @@
 from __future__ import annotations  # Enable forward references in annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 
 from sqlalchemy import delete, func, insert, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -428,7 +428,7 @@ class AssistantRepository(Repository[Assistant]):
                     .values(
                         subscriptions_count=Assistant.subscriptions_count
                         - rows_deleted,
-                        updated_at=datetime.now(timezone.utc),
+                        updated_at=datetime.now(),
                     )
                 )
 

--- a/mucgpt-assistant-service/tests/integration/test_users_router.py
+++ b/mucgpt-assistant-service/tests/integration/test_users_router.py
@@ -523,7 +523,7 @@ def test_subscribe_to_assistant_success(test_client):
     # Validate using SubscriptionResponse model
     subscription_response = SubscriptionResponse.model_validate(subscriptions[0])
     assert subscription_response.id == assistant_id
-    assert subscription_response.name == "Subscribe Test Assistant"
+    assert subscription_response.title == "Subscribe Test Assistant"
 
 
 @pytest.mark.integration
@@ -630,7 +630,7 @@ def test_unsubscribe_from_assistant_success(test_client):
     # Validate using SubscriptionResponse model
     subscription_response = SubscriptionResponse.model_validate(subscriptions_before[0])
     assert subscription_response.id == assistant_id
-    assert subscription_response.name == "Unsubscribe Test Assistant"
+    assert subscription_response.title == "Unsubscribe Test Assistant"
 
     # Unsubscribe from the assistant
     unsubscribe_response = test_client.delete(
@@ -721,7 +721,7 @@ def test_get_user_subscriptions_multiple(test_client):
     assert len(subscriptions) == 2
 
     # Check that we have the correct assistants with simplified structure
-    subscription_names = [sub["name"] for sub in subscriptions]
+    subscription_names = [sub["title"] for sub in subscriptions]
     assert "Subscription Assistant 1" in subscription_names
     assert "Subscription Assistant 2" not in subscription_names
     assert (
@@ -731,14 +731,14 @@ def test_get_user_subscriptions_multiple(test_client):
         # Parse with SubscriptionResponse model to ensure structure is correct
         subscription_response = SubscriptionResponse.model_validate(subscription)
         assert subscription_response.id in [assistant_ids[0], assistant_ids[2]]
-        assert subscription_response.name in [
+        assert subscription_response.title in [
             "Subscription Assistant 1",
             "Subscription Assistant 3",
         ]
 
         # Also validate that only expected fields are present
         assert "id" in subscription
-        assert "name" in subscription
+        assert "title" in subscription
         # Should NOT have complex fields like latest_version
         assert "latest_version" not in subscription
         assert "created_at" not in subscription
@@ -776,7 +776,7 @@ async def test_subscription_lifecycle(test_client, test_db_session):
     # Validate using SubscriptionResponse model
     subscription_response = SubscriptionResponse.model_validate(after_subscribe[0])
     assert subscription_response.id == assistant_id
-    assert subscription_response.name == "Lifecycle Test Assistant"
+    assert subscription_response.title == "Lifecycle Test Assistant"
 
     # Also validate that only expected fields are present
     assert "latest_version" not in after_subscribe[0]
@@ -1161,7 +1161,7 @@ async def test_hierarchical_access_subscription_vs_ownership(
     # Verify subscription was created
     subscriptions = test_client.get("/user/subscriptions", headers=headers).json()
     assert len(subscriptions) == 1
-    assert subscriptions[0]["name"] == "IT Accessible Assistant"
+    assert subscriptions[0]["title"] == "IT Accessible Assistant"
 
 
 @pytest.mark.integration

--- a/mucgpt-frontend/src/api/assistant-client.ts
+++ b/mucgpt-frontend/src/api/assistant-client.ts
@@ -1,12 +1,12 @@
 import { getConfig, handleApiRequest, postConfig, deleteConfig } from "./fetch-utils";
-import { AssistantCreateInput, AssistantCreateResponse, AssistantResponse, AssistantUpdateInput, Assistant } from "./models";
+import { AssistantCreateInput, AssistantCreateResponse, AssistantResponse, AssistantUpdateInput, Assistant, CommunityAssistant } from "./models";
 
 /**
  * Get all assistants the user is subscribed to (ID and name only).
  * @returns Array of SubscriptionResponse
  */
 
-export async function getUserSubscriptionsApi(): Promise<{ id: string; name: string; description: string }[]> {
+export async function getUserSubscriptionsApi(): Promise<CommunityAssistant[]> {
     return handleApiRequest(() => fetch("/api/user/subscriptions", getConfig()), "Failed to get user subscriptions");
 } /**
  * Unsubscribe the current user from an assistant.

--- a/mucgpt-frontend/src/api/models.ts
+++ b/mucgpt-frontend/src/api/models.ts
@@ -227,3 +227,9 @@ export interface User {
     user_roles?: string[];
     authorities?: string[];
 }
+
+export type CommunityAssistant = {
+    title: string;
+    description: string;
+    id: string;
+};

--- a/mucgpt-frontend/src/components/AssistantsettingsDrawer/AssistantsettingsDrawer.module.css
+++ b/mucgpt-frontend/src/components/AssistantsettingsDrawer/AssistantsettingsDrawer.module.css
@@ -285,3 +285,17 @@
 .newChatHeaderContent:hover {
     background-color: var(--colorNeutralBackground1Hover);
 }
+
+.deletedWarning {
+    padding: var(--spacingVerticalM) var(--spacingHorizontalM);
+    background-color: var(--colorPaletteRedBackground1);
+    border: 1px solid var(--colorPaletteRedBorder1);
+    border-radius: var(--borderRadiusMedium);
+    color: var(--colorPaletteRedForeground1);
+    font-size: var(--fontSizeBase300);
+    font-weight: var(--fontWeightSemibold);
+    margin: var(--spacingVerticalM) var(--spacingHorizontalM);
+    display: flex;
+    align-items: center;
+    gap: var(--spacingHorizontalS);
+}

--- a/mucgpt-frontend/src/components/AssistantsettingsDrawer/AssistantsettingsDrawer.tsx
+++ b/mucgpt-frontend/src/components/AssistantsettingsDrawer/AssistantsettingsDrawer.tsx
@@ -29,7 +29,7 @@ import { AssistantStorageService } from "../../service/assistantstorage";
 import { ASSISTANT_STORE } from "../../constants";
 import { Collapse } from "@fluentui/react-motion-components-preview";
 import { deleteCommunityAssistantApi } from "../../api/assistant-client";
-import { AssistantStrategy } from "../../pages/assistant/AssistantStrategy";
+import { AssistantStrategy, DeletedCommunityAssistantStrategy } from "../../pages/assistant/AssistantStrategy";
 
 interface Props {
     assistant: Assistant;
@@ -203,18 +203,23 @@ export const AssistantsettingsDrawer = ({
             <div className={styles.titleSection}>
                 <h3 className={styles.assistantTitle}>{assistant.title}</h3>
             </div>
+            {strategy instanceof DeletedCommunityAssistantStrategy && (
+                <div className={styles.deletedWarning}>
+                    {t("components.assistantsettingsdrawer.deleted_warning")}
+                </div>
+            )}
             <div
                 className={styles.actionsHeader}
                 role="heading"
                 aria-level={4}
-                onClick={clearChat}
+                onClick={clearChatDisabled ? undefined : clearChat}
                 aria-disabled={clearChatDisabled}
                 tabIndex={0}
-                onKeyDown={e => e.key === "Enter" && clearChat()}
+                onKeyDown={clearChatDisabled ? undefined : e => e.key === "Enter" && clearChat()}
             >
                 <div className={styles.newChatHeaderContent}>
                     <ChatAdd24Regular className={styles.actionsIcon} aria-hidden="true" />
-                    <span>New Chat</span>
+                    <span>{t("common.clear_chat")}</span>
                 </div>
             </div>
 
@@ -237,6 +242,7 @@ export const AssistantsettingsDrawer = ({
                     icon={isOwner ? <Edit24Regular /> : <ChatSettings24Regular />}
                     onClick={toggleEditDialog}
                     className={styles.actionButton}
+                    disabled={strategy instanceof DeletedCommunityAssistantStrategy}
                 >
                     {isOwner ? t("components.assistantsettingsdrawer.edit") : t("components.assistantsettingsdrawer.show_configutations")}
                 </Button>

--- a/mucgpt-frontend/src/components/CommunityAssistantDialog/CommunityAssistantDialog.tsx
+++ b/mucgpt-frontend/src/components/CommunityAssistantDialog/CommunityAssistantDialog.tsx
@@ -2,9 +2,9 @@ import { Button, Dialog, DialogBody, DialogContent, DialogSurface, DialogTitle, 
 import { Dismiss24Regular } from "@fluentui/react-icons";
 import { useTranslation } from "react-i18next";
 import { useCallback, useEffect, useState } from "react";
-import { Assistant, AssistantResponse } from "../../api";
-import { AssistantStorageService } from "../../service/assistantstorage";
-import { ASSISTANT_STORE } from "../../constants";
+import { Assistant, AssistantResponse, CommunityAssistant } from "../../api";
+import { CommunityAssistantStorageService } from "../../service/communityassistantstorage";
+import { COMMUNITY_ASSISTANT_STORE } from "../../constants";
 
 // Components
 import { AssistantSearchSection } from "./components/AssistantSearchSection";
@@ -72,7 +72,7 @@ export const CommunityAssistantsDialog = ({
     const [selectedAssistant, setSelectedAssistant] = useState<Assistant>(createMockAssistant());
     const [showAssistantDialog, setShowAssistantDialog] = useState<boolean>(false);
 
-    const communityAssistantStorageService = new AssistantStorageService(ASSISTANT_STORE);
+    const communityAssistantStorageService = new CommunityAssistantStorageService(COMMUNITY_ASSISTANT_STORE);
 
     // sort Functions
     const compareByTitle = (a: AssistantWithMetadata, b: AssistantWithMetadata): number => {
@@ -240,6 +240,12 @@ export const CommunityAssistantsDialog = ({
 
             try {
                 await subscribeToAssistantApi(assistant.id);
+                const community_config: CommunityAssistant = {
+                    id: assistant.id,
+                    title: assistant.title,
+                    description: assistant.description,
+                }
+                await communityAssistantStorageService.createAssistantConfig(community_config);
                 showSuccess(
                     t("components.community_assistants.subscribe_success_title", { title: assistant.title }),
                     t("components.community_assistants.subscribe_success_message")
@@ -274,9 +280,6 @@ export const CommunityAssistantsDialog = ({
             // Load full assistant details
             const fullAssistant = await loadAssistantDetails(assistant.id);
             setSelectedAssistant(fullAssistant);
-
-            // Update storage service
-            communityAssistantStorageService.getAssistantConfig(assistant.id);
         } catch (error) {
             // Error is handled in the hook
             console.error("Failed to load assistant details:", error);

--- a/mucgpt-frontend/src/constants.ts
+++ b/mucgpt-frontend/src/constants.ts
@@ -42,6 +42,12 @@ export const CHAT_STORE: IndexedDBStorage = {
     db_version: 3
 };
 
+export const COMMUNITY_ASSISTANT_STORE: IndexedDBStorage = {
+    db_name: "MUCGPT-COMMUNITY-ASSISTANTS",
+    objectStore_name: "assistants",
+    db_version: 1
+};
+
 // Create Assistant examples
 export const CREATE_ASSISTANT_EXAMPLE_1 = "Englischübersetzer: Der Assistent übersetzt den eingegebenen Text ins Englische.";
 export const CREATE_ASSISTANT_EXAMPLE_2 =

--- a/mucgpt-frontend/src/i18n.ts
+++ b/mucgpt-frontend/src/i18n.ts
@@ -41,6 +41,8 @@ i18n
                         own_assistants_list: "Eigene Assistenten",
                         owned_assistants_list: "Eigene Community Assistenten",
                         subscribed_assistants_list: "Abonnierte Community Assistenten",
+                        deleted: "Gelöschte:",
+                        deleted_assistants_list: "Gelöschte Community Assistenten",
                         select_assistant_aria: "Assistent auswählen: {{title}}",
                         share_assistant_aria: "Assistent teilen: {{title}}"
                     },
@@ -248,6 +250,7 @@ i18n
                             "remove-assistant": "Assistent entfernen",
                             publish: "Veröffentlichen",
                             unpublish: "Nicht mehr veröffentlichen",
+                            deleted_warning: "Dieser Assistent wurde aus der Community gelöscht und ist nicht mehr verfügbar.",
                             deleteDialog: {
                                 title: "Assistent Löschen",
                                 content: "Wollen Sie den Assistenten wirklich löschen? Dies kann nicht rückgängig gemacht werden.",
@@ -468,6 +471,8 @@ i18n
                         own_assistants_list: "Your assistants",
                         owned_assistants_list: "Your community assistants",
                         subscribed_assistants_list: "Subscribed community assistants",
+                        deleted: "Deleted:",
+                        deleted_assistants_list: "Deleted community assistants",
                         select_assistant_aria: "Select assistant: {{title}}",
                         share_assistant_aria: "Share assistant: {{title}}"
                     },
@@ -674,6 +679,7 @@ i18n
                             "remove-assistant": "Remove Assistant",
                             publish: "Publish",
                             unpublish: "Unpublish",
+                            deleted_warning: "This assistant has been deleted from the community and is no longer available.",
                             deleteDialog: {
                                 title: "Delete Assistant",
                                 content: "Are you sure you want to delete the assistant? This action cannot be undone.",
@@ -892,6 +898,8 @@ i18n
                         own_assistants_list: "Deina Assistentn",
                         owned_assistants_list: "Deina Community-Assistentn",
                         subscribed_assistants_list: "Abonniert Community-Assistentn",
+                        deleted: "Glöschte:",
+                        deleted_assistants_list: "Glöschte Community-Assistentn",
                         select_assistant_aria: "Assistent aussuacha: {{title}}",
                         share_assistant_aria: "Assistent teilen: {{title}}"
                     },
@@ -1099,6 +1107,7 @@ i18n
                             "remove-assistant": "Assistent entfern'n",
                             publish: "Veröffentlich'n",
                             unpublish: "Nimma veröffentlich'n",
+                            deleted_warning: "Der Assistent is aus da Community glöscht wordn und is nimma verfügbar.",
                             deleteDialog: {
                                 title: "Assistent Löschn",
                                 content: "Wuißt du den Assistenten echt löschn? Des ko nimma rückgängig gmocht werdn.",
@@ -1318,6 +1327,8 @@ i18n
                         own_assistants_list: "Vos assistants",
                         owned_assistants_list: "Vos assistants communautaires",
                         subscribed_assistants_list: "Assistants communautaires abonnés",
+                        deleted: "Supprimés:",
+                        deleted_assistants_list: "Assistants communautaires supprimés",
                         select_assistant_aria: "Sélectionner l'assistant : {{title}}",
                         share_assistant_aria: "Partager l'assistant : {{title}}"
                     },
@@ -1525,6 +1536,7 @@ i18n
                             "remove-assistant": "Retirer l'assistant",
                             publish: "Publier",
                             unpublish: "Dépublier",
+                            deleted_warning: "Cet assistant a été supprimé de la communauté et n'est plus disponible.",
                             deleteDialog: {
                                 title: "Supprimer l'Assistant",
                                 content: "Êtes-vous sûr de vouloir supprimer l'assistant ? Cette action ne peut pas être annulée.",
@@ -1745,6 +1757,8 @@ i18n
                         own_assistants_list: "Ваші асистенти",
                         owned_assistants_list: "Ваші асистенти спільноти",
                         subscribed_assistants_list: "Підписані асистенти спільноти",
+                        deleted: "Видалені:",
+                        deleted_assistants_list: "Видалені асистенти спільноти",
                         select_assistant_aria: "Вибрати асистента: {{title}}",
                         share_assistant_aria: "Поділитися асистентом: {{title}}"
                     },
@@ -1952,6 +1966,7 @@ i18n
                             "remove-assistant": "Видалити асистента",
                             publish: "Опублікувати",
                             unpublish: "Скасувати публікацію",
+                            deleted_warning: "Цей асистент був видалений з спільноти і більше не доступний.",
                             deleteDialog: {
                                 title: "Видалити Бота",
                                 content: "Ви впевнені, що хочете видалити бота? Цю дію не можна скасувати.",

--- a/mucgpt-frontend/src/index.tsx
+++ b/mucgpt-frontend/src/index.tsx
@@ -17,9 +17,10 @@ import { LLMContextProvider } from "./components/LLMSelector/LLMContextProvider"
 import { QuickPromptProvider } from "./components/QuickPrompt/QuickPromptProvider";
 import { HeaderContextProvider } from "./pages/layout/HeaderContextProvider";
 import LocalAssistant from "./pages/assistant/LocalAssistant";
-import RefactoredOwnedCommunityAssistant from "./pages/assistant/OwnedCommunityAssistant";
-import RefactoredCommunityAssistant from "./pages/assistant/CommunityAssistant";
+import OwnedCommunityAssistant from "./pages/assistant/OwnedCommunityAssistant";
+import CommunityAssistant from "./pages/assistant/CommunityAssistant";
 import { GlobalToastProvider } from "./components/GlobalToastHandler/GlobalToastContext";
+import DeletedCommunityAssistant from "./pages/assistant/DeletedCommunityAssistant";
 initializeIcons();
 
 const router = createHashRouter([
@@ -80,12 +81,17 @@ const router = createHashRouter([
             },
             {
                 path: "owned/communityassistant/:id",
-                element: <RefactoredOwnedCommunityAssistant />,
+                element: <OwnedCommunityAssistant />,
+                errorElement: <div>Fehler</div>
+            },
+            {
+                path: "deleted/communityassistant/:id",
+                element: <DeletedCommunityAssistant />,
                 errorElement: <div>Fehler</div>
             },
             {
                 path: "communityassistant/:id",
-                element: <RefactoredCommunityAssistant />,
+                element: <CommunityAssistant />,
                 errorElement: <div>Fehler</div>
             },
             /** {

--- a/mucgpt-frontend/src/pages/assistant/DeletedCommunityAssistant.tsx
+++ b/mucgpt-frontend/src/pages/assistant/DeletedCommunityAssistant.tsx
@@ -1,0 +1,8 @@
+import UnifiedAssistantChat from "./UnifiedAssistantChat";
+import { DeletedCommunityAssistantStrategy } from "./AssistantStrategy";
+
+const DeletedCommunityAssistantChat = () => {
+    return <UnifiedAssistantChat strategy={new DeletedCommunityAssistantStrategy()} />;
+};
+
+export default DeletedCommunityAssistantChat;

--- a/mucgpt-frontend/src/pages/assistant/UnifiedAssistantChat.tsx
+++ b/mucgpt-frontend/src/pages/assistant/UnifiedAssistantChat.tsx
@@ -20,7 +20,7 @@ import { STORAGE_KEYS } from "../layout/LayoutHelper";
 import { HeaderContext } from "../layout/HeaderContextProvider";
 import ToolStatusDisplay from "../../components/ToolStatusDisplay";
 import { ToolStatus } from "../../utils/ToolStreamHandler";
-import { AssistantStrategy, CommunityAssistantStrategy } from "./AssistantStrategy";
+import { AssistantStrategy, CommunityAssistantStrategy, DeletedCommunityAssistantStrategy } from "./AssistantStrategy";
 import { chatApi } from "../../api/core-client";
 import { useGlobalToastContext } from "../../components/GlobalToastHandler/GlobalToastContext";
 import { getOwnedCommunityAssistants, getUserSubscriptionsApi, subscribeToAssistantApi } from "../../api/assistant-client";
@@ -397,13 +397,13 @@ const UnifiedAssistantChat = ({ strategy }: UnifiedAssistantChatProps) => {
             <>
                 <AssistantsettingsDrawer
                     assistant={assistantConfig}
-                    onAssistantChange={strategy.canEdit ? onAssistantChanged : () => {}}
+                    onAssistantChange={strategy.canEdit ? onAssistantChanged : () => { }}
                     onDeleteAssistant={onDeleteAssistant}
                     history={history}
                     minimized={!showSidebar}
                     isOwned={strategy.isOwned}
                     clearChat={clearChat}
-                    clearChatDisabled={!lastQuestionRef.current || isLoadingRef.current}
+                    clearChatDisabled={!lastQuestionRef.current || isLoadingRef.current || strategy instanceof DeletedCommunityAssistantStrategy}
                     onToggleMinimized={toggleSidebar}
                     strategy={strategy}
                 ></AssistantsettingsDrawer>
@@ -427,14 +427,14 @@ const UnifiedAssistantChat = ({ strategy }: UnifiedAssistantChatProps) => {
             <QuestionInput
                 clearOnSend
                 placeholder={t("chat.prompt")}
-                disabled={isLoadingRef.current || error !== undefined}
+                disabled={isLoadingRef.current || error !== undefined || strategy instanceof DeletedCommunityAssistantStrategy}
                 onSend={question => callApi(question)}
                 question={question}
                 setQuestion={question => setQuestion(question)}
                 selectedTools={assistantConfig.tools ? assistantConfig.tools.map(tool => tool.id) : []}
             />
         ),
-        [isLoadingRef.current, callApi, question, t, error, assistantConfig.tools]
+        [isLoadingRef.current, callApi, question, t, error, assistantConfig.tools, strategy]
     );
 
     // AnswerList component

--- a/mucgpt-frontend/src/service/communityassistantstorage.ts
+++ b/mucgpt-frontend/src/service/communityassistantstorage.ts
@@ -1,0 +1,133 @@
+import { StorageService } from "./storage";
+import { ChatResponse, CommunityAssistant } from "../api";
+import { IndexedDBStorage } from "./indexedDBStorage";
+
+/**
+ * Service for storing and retrieving community assistant configurations.
+ */
+export class CommunityAssistantStorageService {
+    // service to handling with the indexeddb
+    private storageService: StorageService<ChatResponse, CommunityAssistant>;
+    // contains the name of the assistant indexeddb and the corresponding object store
+    private config: IndexedDBStorage;
+    static CONFIG_ID = "COMMUNITYASSISTANTCONFIG_";
+
+    constructor(config: IndexedDBStorage) {
+        this.storageService = new StorageService<ChatResponse, CommunityAssistant>(config);
+        this.config = config;
+    }
+
+    /****************************
+     * Helper methods
+     ***************************/
+
+    /**
+     * Returns a new instance of StorageService for chat storage.
+     * @returns New StorageService instance for ChatResponse and CommunityAssistant.
+     */
+    getChatStorageService() {
+        return new StorageService<ChatResponse, CommunityAssistant>(this.config);
+    }
+
+    /**
+     * Retrieves all configurations matching the filter predicate.
+     * @param filter_predicate Function to check if an ID matches the desired criteria.
+     * @returns Array of matching configurations.
+     */
+    private async _getAllConfigs(filter_predicate: (id: string) => boolean) {
+        const results = await this.storageService.getAll();
+        if (results)
+            return results.filter(config => {
+                if (config.id) {
+                    return filter_predicate(config.id);
+                }
+                return false;
+            });
+        else return [];
+    }
+
+    /****************************
+     * ID creation
+     ***************************/
+
+    /**
+     * Generates a unique ID for the community assistant configuration.
+     * @param id Base ID
+     * @returns Generated configuration ID
+     */
+    static GENERATE_COMMUNITY_ASSISTANT_CONFIG_ID(id: string) {
+        return CommunityAssistantStorageService.CONFIG_ID + id;
+    }
+
+    /****************************
+     * Assistant configuration
+     ***************************/
+
+    /**
+     * Creates and stores a new community assistant configuration.
+     * @param assistant_config The configuration of the CommunityAssistant
+     * @param id The unique ID
+     * @returns The used ID
+     */
+    async createAssistantConfig(assistant_config: CommunityAssistant) {
+        const config_with_id = { ...assistant_config, ...{ id: assistant_config.id } };
+        await this.storageService.create([], config_with_id, CommunityAssistantStorageService.GENERATE_COMMUNITY_ASSISTANT_CONFIG_ID(assistant_config.id));
+        return assistant_config.id;
+    }
+
+    /**
+     * Retrieves the configuration of a community assistant by ID.
+     * @param assistant_id The assistant's ID
+     * @returns The configuration or undefined
+     */
+    async getAssistantConfig(assistant_id: string) {
+        return await this.storageService.get(CommunityAssistantStorageService.GENERATE_COMMUNITY_ASSISTANT_CONFIG_ID(assistant_id)).then(assistant_config => {
+            if (assistant_config) return assistant_config.config;
+            else return undefined;
+        });
+    }
+
+    /**
+     * Updates the configuration of a community assistant.
+     * @param assistant_id The assistant's ID
+     * @param assistant_config The new configuration
+     */
+    async setAssistantConfig(assistant_id: string, assistant_config: CommunityAssistant) {
+        await this.storageService.update(
+            CommunityAssistantStorageService.GENERATE_COMMUNITY_ASSISTANT_CONFIG_ID(assistant_id),
+            undefined,
+            assistant_config,
+            undefined,
+            CommunityAssistantStorageService.GENERATE_COMMUNITY_ASSISTANT_CONFIG_ID(assistant_id)
+        );
+    }
+
+    /**
+     * Retrieves all stored community assistant configurations.
+     * @returns Array of all configurations
+     */
+    async getAllAssistantConfigs() {
+        const assistants = await this._getAllConfigs((id: string) => id.startsWith(CommunityAssistantStorageService.CONFIG_ID));
+        const assistant_configs = assistants.map(config => {
+            return config.config;
+        });
+        return assistant_configs;
+    }
+
+    /****************************
+     * Delete
+     ***************************/
+
+    /**
+     * Deletes the configuration of a community assistant by ID.
+     * @param assistant_id The assistant's ID
+     */
+    async deleteConfigForAssistant(assistant_id: string) {
+        const results = await this._getAllConfigs((id: string) => id === CommunityAssistantStorageService.GENERATE_COMMUNITY_ASSISTANT_CONFIG_ID(assistant_id));
+        for (let i = 0; i < results.length; i++) {
+            if (results[i].id) {
+                await this.storageService.delete(results[i].id ?? "");
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Description**

Wenn ein Community-Assistent gelöscht wird, aber weiterhin von Benutzern abonniert ist, wird dieser gelöschte Assistent nun in einem separaten Bereich im Menü angezeigt. So haben die Nutzer die Möglichkeit, ihre Chats zu sichern, auch wenn das Chatten mit dem Assistenten selbst nicht mehr möglich ist.

Am besten zu testen in zwei verschieden Browsern mit zwei Benutzern.
