### PR TITLE
smaller ui fixes and improvements

### DIFF
--- a/mucgpt-frontend/src/components/ChatLayout/ChatLayout.module.css
+++ b/mucgpt-frontend/src/components/ChatLayout/ChatLayout.module.css
@@ -113,8 +113,8 @@
     bottom: 10px;
     flex: 0 0 100px;
     padding-bottom: 60px;
-    max-width: 90%;
-    min-width: 50%;
+    max-width: 100%;
+    min-width: 80%;
 }
 
 .sidebarOpener {

--- a/mucgpt-frontend/src/components/QuestionInput/QuestionInput.tsx
+++ b/mucgpt-frontend/src/components/QuestionInput/QuestionInput.tsx
@@ -1,6 +1,6 @@
 import { Stack } from "@fluentui/react";
 import { Button, Textarea, TextareaOnChangeData, Tooltip, Badge } from "@fluentui/react-components";
-import { Send28Filled, Toolbox24Color } from "@fluentui/react-icons";
+import { Dismiss24Regular, Send28Filled, Toolbox24Color } from "@fluentui/react-icons";
 
 import styles from "./QuestionInput.module.css";
 import { useTranslation } from "react-i18next";
@@ -146,9 +146,7 @@ export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend, ques
                                         }}
                                         icon={
                                             setSelectedTools && (
-                                                <span className={styles.toolBadgeIcon} aria-label={`Entferne ${toolName}`}>
-                                                    ✕
-                                                </span>
+                                                <Dismiss24Regular className={styles.toolBadgeIcon} aria-label={`Entferne ${toolName}`} />
                                             )
                                         }
                                     >

--- a/mucgpt-frontend/src/components/TermsOfUseDialog/TermsOfUseDialog.tsx
+++ b/mucgpt-frontend/src/components/TermsOfUseDialog/TermsOfUseDialog.tsx
@@ -1,5 +1,5 @@
 import { Dialog, DialogTrigger, DialogSurface, DialogTitle, DialogBody, DialogActions, DialogContent, Button, Link, Tooltip } from "@fluentui/react-components";
-import { Checkmark24Filled, TextBulletList24Regular } from "@fluentui/react-icons";
+import { Checkmark24Filled, DocumentBulletListMultiple24Regular } from "@fluentui/react-icons";
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
 
@@ -20,7 +20,7 @@ export const TermsOfUseDialog = ({ defaultOpen, onAccept }: TermsOfUseDialogProp
                 <DialogTrigger disableButtonEnhancement>
                     <Tooltip content={t("components.terms_of_use.tooltip", "Nutzungsbedingungen anzeigen")} relationship="description" positioning="above">
                         <div className={styles.triggerContainer}>
-                            <TextBulletList24Regular className={styles.termsIcon} />
+                            <DocumentBulletListMultiple24Regular className={styles.termsIcon} />
                             <span className={styles.termsText}>{t("components.terms_of_use.label", "Nutzungsbedingungen")}</span>
                         </div>
                     </Tooltip>

--- a/mucgpt-frontend/src/components/ThemeSelector/ThemeSelector.module.css
+++ b/mucgpt-frontend/src/components/ThemeSelector/ThemeSelector.module.css
@@ -23,9 +23,9 @@
 .buttonContainer {
     display: flex;
     align-items: center;
-    gap: 4px;
+    gap: 8px;
     cursor: pointer;
-    padding: 4px;
+    padding: 8px;
     border-radius: 4px;
     transition: background-color 0.2s;
 }
@@ -41,5 +41,11 @@
 
 .darkTheme {
     background-color: var(--colorNeutralForeground1);
+    color: var(--colorNeutralForeground1);
+}
+
+.text {
+    font-size: 14px;
+    font-weight: 500;
     color: var(--colorNeutralForeground1);
 }

--- a/mucgpt-frontend/src/components/ThemeSelector/ThemeSelector.tsx
+++ b/mucgpt-frontend/src/components/ThemeSelector/ThemeSelector.tsx
@@ -1,6 +1,6 @@
 import { Tooltip } from "@fluentui/react-components";
 import { useState, useEffect, useCallback } from "react";
-import { DarkTheme24Regular, LightbulbCircle24Regular } from "@fluentui/react-icons";
+import { WeatherSunny24Regular, WeatherMoon24Regular } from "@fluentui/react-icons";
 import styles from "./ThemeSelector.module.css";
 import { useTranslation } from "react-i18next";
 
@@ -46,9 +46,15 @@ export const ThemeSelector = ({ isLight, onThemeChange }: ThemeSelectorProps) =>
             <div className={styles.container} onClick={handleButtonClick} role="button" tabIndex={0} aria-label={tooltipContent} onKeyDown={handleKeyDown}>
                 <div className={styles.buttonContainer}>
                     {currentIsLight ? (
-                        <LightbulbCircle24Regular className={styles.iconRightMargin} />
+                        <>
+                            <WeatherSunny24Regular className={styles.iconRightMargin} />
+                            <span className={styles.text}>{t("components.theme_selector.light_short")}</span>
+                        </>
                     ) : (
-                        <DarkTheme24Regular className={styles.iconRightMargin} />
+                        <>
+                            <WeatherMoon24Regular className={styles.iconRightMargin} />
+                            <span className={styles.text}>{t("components.theme_selector.dark_short")}</span>
+                        </>
                     )}
                 </div>
             </div>

--- a/mucgpt-frontend/src/components/VersionInfo/VersionInfo.module.css
+++ b/mucgpt-frontend/src/components/VersionInfo/VersionInfo.module.css
@@ -33,6 +33,7 @@
     padding: 4px 8px;
     border-radius: 4px;
     transition: background-color 0.2s;
+    text-decoration: underline;
 }
 
 .versionLink:hover {

--- a/mucgpt-frontend/src/components/VersionInfo/VersionInfo.tsx
+++ b/mucgpt-frontend/src/components/VersionInfo/VersionInfo.tsx
@@ -27,11 +27,14 @@ export const VersionInfo = ({ version, commit, versionUrl }: VersionInfoProps) =
 
     if (versionUrl) {
         return (
-            <Tooltip content={tooltipContent} relationship="description" positioning="above">
-                <a href={versionUrl} className={styles.versionLink}>
+            <>
+                <Tooltip content={tooltipContent} relationship="description" positioning="above">
                     {content}
+                </Tooltip>
+                <a href={versionUrl} className={styles.versionLink}>
+                    {t("components.versioninfo.whats_new", "Was gibt's neues?")}
                 </a>
-            </Tooltip>
+            </>
         );
     }
 
@@ -43,3 +46,4 @@ export const VersionInfo = ({ version, commit, versionUrl }: VersionInfoProps) =
 };
 
 export default VersionInfo;
+

--- a/mucgpt-frontend/src/i18n.ts
+++ b/mucgpt-frontend/src/i18n.ts
@@ -160,7 +160,8 @@ i18n
                         versioninfo: {
                             tooltip: "Anwendungs-Version anzeigen",
                             tooltip_with_commit: "Anwendungs-Version: {{version}}, Commit: {{commit}}",
-                            label: "Version:"
+                            label: "Version:",
+                            whats_new: "Was gibt's neues?"
                         },
                         feedback: {
                             tooltip: "Feedback geben",
@@ -176,7 +177,9 @@ i18n
                         theme_selector: {
                             theme_light: "Helles Thema",
                             theme_dark: "Dunkles Thema",
-                            change_theme: "Thema wechseln"
+                            change_theme: "Thema wechseln",
+                            light_short: "Hell",
+                            dark_short: "Dunkel"
                         },
                         sumlength: {
                             sentences: "Zwei Sätze",
@@ -492,8 +495,8 @@ i18n
                             informal_tooltip: "Write your answer more informal",
                             shorter: "➖ less detail",
                             longer: "➕  more detail",
-                            formal: "👕 more formal",
-                            informal: "more informal",
+                            formal: "👔 more formal",
+                            informal: "👕 more informal",
                             shorter_prompt:
                                 "Rewrite your last message into a new, shorter text that conveys the original content in a more concise and impactful way. This text should include the most important information and improve the reader's understanding.",
                             longer_prompt:
@@ -594,7 +597,8 @@ i18n
                         versioninfo: {
                             tooltip: "Show application version",
                             tooltip_with_commit: "Application version: {{version}}, Commit: {{commit}}",
-                            label: "Version:"
+                            label: "Version:",
+                            whats_new: "What's new?"
                         },
                         feedback: {
                             tooltip: "Give feedback",
@@ -610,7 +614,9 @@ i18n
                         theme_selector: {
                             theme_light: "Light theme",
                             theme_dark: "Dark theme",
-                            change_theme: "Change theme"
+                            change_theme: "Change theme",
+                            light_short: "Light",
+                            dark_short: "Dark"
                         },
                         sumlength: {
                             sentences: "Two sentences",
@@ -1027,7 +1033,8 @@ i18n
                         versioninfo: {
                             tooltip: "Anwendungs-Version zeig'n",
                             tooltip_with_commit: "Anwendungs-Version: {{version}}, Commit: {{commit}}",
-                            label: "Version:"
+                            label: "Version:",
+                            whats_new: "Wos gibt's Nei's?"
                         },
                         feedback: {
                             tooltip: "Feedback geb'n",
@@ -1043,7 +1050,9 @@ i18n
                         theme_selector: {
                             theme_light: "Helles Thema",
                             theme_dark: "Dunkles Thema",
-                            change_theme: "Thema wechs'l"
+                            change_theme: "Thema wechs'l",
+                            light_short: "Hell",
+                            dark_short: "Dunkl"
                         },
                         sumlength: {
                             sentences: "Zwoa Sätzen",
@@ -1459,9 +1468,10 @@ i18n
                             accept: "Accepter"
                         },
                         versioninfo: {
-                            tooltip: "Pоказати версію програми",
-                            tooltip_with_commit: "Версія програми: {{version}}, Commit: {{commit}}",
-                            label: "Версія:"
+                            tooltip: "Afficher la version de l'application",
+                            tooltip_with_commit: "Version de l'application: {{version}}, Commit: {{commit}}",
+                            label: "Version:",
+                            whats_new: "Quoi de neuf ?"
                         },
                         feedback: {
                             tooltip: "Donner un avis",
@@ -1477,7 +1487,9 @@ i18n
                         theme_selector: {
                             theme_light: "Thème clair",
                             theme_dark: "Thème sombre",
-                            change_theme: "Changer de thème"
+                            change_theme: "Changer de thème",
+                            light_short: "Clair",
+                            dark_short: "Sombre"
                         },
                         sumlength: {
                             sentences: "Deux phrases",
@@ -1896,7 +1908,8 @@ i18n
                         versioninfo: {
                             tooltip: "Показати версію програми",
                             tooltip_with_commit: "Версія програми: {{version}}, Commit: {{commit}}",
-                            label: "Версія:"
+                            label: "Версія:",
+                            whats_new: "Що нового?"
                         },
                         feedback: {
                             tooltip: "Залишити відгук",
@@ -1912,7 +1925,9 @@ i18n
                         theme_selector: {
                             theme_light: "Світла тема",
                             theme_dark: "Темна тема",
-                            change_theme: "Змінити тему"
+                            change_theme: "Змінити тему",
+                            light_short: "Світло",
+                            dark_short: "Темно"
                         },
                         sumlength: {
                             sentences: "Два речення",

--- a/mucgpt-frontend/src/pages/faq/Faq.module.css
+++ b/mucgpt-frontend/src/pages/faq/Faq.module.css
@@ -43,7 +43,7 @@
 
 .commandsContainer {
     position: fixed;
-    top: 16px;
+    top: 64px;
     right: 32px;
     display: flex;
     justify-content: flex-end;

--- a/mucgpt-frontend/src/pages/menu/Menu.module.css
+++ b/mucgpt-frontend/src/pages/menu/Menu.module.css
@@ -65,6 +65,7 @@
     justify-content: center;
     margin-top: 20px;
     margin-bottom: 30px;
+    gap: 16px;
 }
 
 .chatNavigationButton {

--- a/mucgpt-frontend/src/pages/version/Version.module.css
+++ b/mucgpt-frontend/src/pages/version/Version.module.css
@@ -43,7 +43,7 @@
 
 .commandsContainer {
     position: fixed;
-    top: 16px;
+    top: 64px;
     right: 32px;
     display: flex;
     justify-content: flex-end;


### PR DESCRIPTION
**Description**

- bigger chat input
- fixed close button for faq and version page
- changed them icon + text
- terms-of-use icon
- gap between buttons on start page
- fixed english recommended answers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme selector now shows icons with short “Light/Dark” labels and updated tooltips.
  * Added localized “What’s new?” label across supported languages.

* **Style**
  * Wider chat input (max-width 100%, min-width 80%).
  * Increased gaps/padding in theme selector and added text styling.
  * Version link now underlined by default.
  * Adjusted fixed command bars’ top offset to 64px; added navigation gaps.
  * Replaced icons in question input and terms dialog for improved clarity.

* **Refactor**
  * Version info now separates the tooltip content from the external “What’s new?” link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->