### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-core-service.yaml
+++ b/.github/workflows/test-core-service.yaml
@@ -1,4 +1,6 @@
 name: Core service test
+permissions:
+  contents: read
 
 on: [push, workflow_dispatch]
 


### PR DESCRIPTION
Potential fix for [https://github.com/it-at-m/mucgpt/security/code-scanning/7](https://github.com/it-at-m/mucgpt/security/code-scanning/7)

To fix this problem, add a `permissions` key at the root level of the workflow file `.github/workflows/test-core-service.yaml` (above or below the `name:` key but before `jobs:`), or inside the individual job definition if job-specific permissions are needed. The minimal starting point is:
```yaml
permissions:
  contents: read
```
This gives the workflow read-only access to repository contents via `GITHUB_TOKEN`, which suffices for checking out code and running tests; no write access is required for the described steps. This change should be made at the root of the workflow to apply to all jobs, unless job-specific permissions are needed.

No additional imports or definitions are needed; this is a straightforward YAML structural edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to enhance permissions management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->