### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -1,4 +1,8 @@
 name: 'Close stale issues and PRs'
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
 on:
   schedule:
     - cron: '30 1 * * *'


### PR DESCRIPTION
Potential fix for [https://github.com/it-at-m/mucgpt/security/code-scanning/1](https://github.com/it-at-m/mucgpt/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow, either at the root level or inside the affected job (`stale`). The workflow uses `actions/stale`, which requires `issues: write`, `pull-requests: write`, and optionally `contents: write` permissions. Adding an explicit `permissions` block either as a top-level key (to cover all jobs) or within `jobs.stale` will make the job’s security posture explicit and follow the principle of least privilege. The best practice is to include it at the top level, unless other jobs in the workflow need significantly different permissions, which is not the case here since there's only a single job. Thus, the `permissions` block should be added below the `name` or `on` key in `.github/workflows/stale-bot.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions for the stale bot to enable proper access to repository contents, issues, and pull requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->