### PR TITLE
Fixing initial publishing assistant workflow

### DIFF
--- a/mucgpt-frontend/src/components/PublishAssistantDialog/PublishAssistantDialog.tsx
+++ b/mucgpt-frontend/src/components/PublishAssistantDialog/PublishAssistantDialog.tsx
@@ -51,7 +51,7 @@ export const PublishAssistantDialog = ({ open, setOpen, assistant, invisibleChec
                 hierarchical_access = publishDepartments;
                 is_visible = true;
             } else {
-                hierarchical_access = ["*"];
+                hierarchical_access = [];
                 is_visible = true;
             }
 


### PR DESCRIPTION
**Description**
In case of public assistants, no more `*` departments is set. Its just an empty array, that means everyone can use it.

**Reference**

Closes #714 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the handling of department access permissions when publishing assistants with public visibility mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->