### PR TITLE
Update contact email in Terms of Use dialog

### DIFF
--- a/mucgpt-frontend/src/components/TermsOfUseDialog/TermsOfUseDialog.tsx
+++ b/mucgpt-frontend/src/components/TermsOfUseDialog/TermsOfUseDialog.tsx
@@ -113,9 +113,9 @@ export const TermsOfUseDialog = ({ defaultOpen, onAccept }: TermsOfUseDialogProp
                             <div className={styles.responsibleContainer}>
                                 Verantwortlich für die Nutzungsbedingungen ist RIT-I (STRAC). Bei Fragen oder Anmerkungen hierzu bitte an folgende E-Mail
                                 Adresse wenden:
-                                <Link inline className={styles.link} href="mailto:it-vorschriften.strac.rit@muenchen.de?subject=MUCGPT">
+                                <Link inline className={styles.link} href="mailto:it-vorschriften.rit@muenchen.de?subject=MUCGPT">
                                     {" "}
-                                    it-vorschriften.strac.rit@muenchen.de
+                                    it-vorschriften.rit@muenchen.de
                                 </Link>
                             </div>
                         </DialogContent>


### PR DESCRIPTION
**Description**

Replaced the contact email in the Terms of Use dialog with it-vorschriften.rit@muenchen.de.

**Reference**

Closes #791 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the contact email address in the Terms of Use Dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->