### PR TITLE
Render markdown in assistant descriptions

### DIFF
--- a/mucgpt-frontend/src/components/AssistantDetailsSidebar/AssistantDetailsSidebar.module.css
+++ b/mucgpt-frontend/src/components/AssistantDetailsSidebar/AssistantDetailsSidebar.module.css
@@ -120,6 +120,13 @@
     font-size: 16px;
 }
 
+.descriptionContainer {
+    background-color: var(--colorNeutralBackground1);
+    padding: 12px;
+    border-radius: 8px;
+    border: 1px solid var(--colorNeutralStroke2);
+}
+
 .aboutText {
     font-size: 14px;
     line-height: 1.6;

--- a/mucgpt-frontend/src/components/AssistantDetailsSidebar/AssistantDetailsSidebar.tsx
+++ b/mucgpt-frontend/src/components/AssistantDetailsSidebar/AssistantDetailsSidebar.tsx
@@ -163,7 +163,9 @@ export const AssistantDetailsSidebar = ({
                                 <Book24Regular className={styles.sectionIcon} />
                                 <span>{t("components.community_assistants.about", "ABOUT")}</span>
                             </div>
-                            <Text className={styles.aboutText}>{assistant?.description}</Text>
+                            <div className={styles.descriptionContainer}>
+                                <MarkdownRenderer className={styles.aboutText}>{assistant?.description ?? ""}</MarkdownRenderer>
+                            </div>
                         </div>
 
                         {enabledTools.length > 0 && (

--- a/mucgpt-frontend/src/components/ChatLayout/ChatLayout.module.css
+++ b/mucgpt-frontend/src/components/ChatLayout/ChatLayout.module.css
@@ -16,8 +16,7 @@
     padding: 0 16px;
     background: var(--colorNeutralBackground1);
     z-index: 5;
-    transition:
-        left 220ms cubic-bezier(0.2, 0.9, 0.2, 1);
+    transition: left 220ms cubic-bezier(0.2, 0.9, 0.2, 1);
     box-sizing: border-box;
 }
 

--- a/mucgpt-frontend/src/components/DiscoveryCard/DiscoveryCard.tsx
+++ b/mucgpt-frontend/src/components/DiscoveryCard/DiscoveryCard.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef, ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 import { Card, CardHeader, CardPreview, mergeClasses, CardProps } from "@fluentui/react-components";
 import styles from "./DiscoveryCard.module.css";
+import { MarkdownRenderer } from "../MarkdownRenderer/MarkdownRenderer";
 
 export interface DiscoveryCardProps extends CardProps {
     id?: string;
@@ -54,7 +55,11 @@ export const DiscoveryCard = forwardRef<HTMLDivElement, DiscoveryCardProps>((pro
     const cardContent = (
         <Card id={id} ref={ref} className={mergeClasses(styles.card, isSelected && styles.cardSelected, className)} onClick={handleClick} {...rest}>
             {renderHeader()}
-            {description && <CardPreview className={styles.description}>{description}</CardPreview>}
+            {description && (
+                <CardPreview className={styles.description}>
+                    <MarkdownRenderer>{description}</MarkdownRenderer>
+                </CardPreview>
+            )}
         </Card>
     );
 


### PR DESCRIPTION
**Description**

Assistant description can contain markdown description for more detailed user instructions. render that!


**Reference**

Closes #786


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Markdown formatting support for assistant descriptions and discovery card descriptions, enabling richer text formatting.

* **Style**
  * Enhanced visual styling for description containers with improved padding, borders, and background styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->