### PR TITLE
💄limited title length in the card visually

### DIFF
--- a/mucgpt-frontend/src/components/DiscoveryCard/DiscoveryCard.module.css
+++ b/mucgpt-frontend/src/components/DiscoveryCard/DiscoveryCard.module.css
@@ -27,6 +27,11 @@
     transition-property: color;
     transition-duration: 0.2s;
     padding-top: 12px;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow-wrap: break-word;
 }
 
 .description {


### PR DESCRIPTION
## Summary
What changed?
Limits long titles in Discovery Cards to two lines so cards stay visually aligned within the same row.

## Why
Why is this change needed?
Very long assistant titles could make individual cards taller than others and break the layout in the Discovery view.

## Validation
How was this verified?
- [ ] Automated tests
- [x] Manual verification
- [ ] Not applicable

## UI Changes (If applicable)
*Please add screenshots or screencasts of any visual changes.*

## Change Areas
- [x] Frontend
- [ ] Core service
- [ ] Assistant service
- [ ] Migrations / DB
- [ ] Infrastructure / Docker / Compose / Keycloak
- [ ] CI / CD
- [ ] Docs

## Risks / Rollout Notes
Is there anything reviewers or operators should pay attention to?
*Examples: breaking changes, config changes, migration order, deployment considerations, rollback concerns.*

## References
Related: #
Closes: #819 
