### PR TITLE
changed department name to "DAICE" & made link configurable

### DIFF
--- a/mucgpt-core-service/app/api/api_models.py
+++ b/mucgpt-core-service/app/api/api_models.py
@@ -409,3 +409,7 @@ class ConfigResponse(BaseModel):
         False,
         description="Whether document upload and parsing is enabled. True when a parser backend (e.g. Kreuzberg) is configured.",
     )
+    footer_link_url: str | None = Field(
+        None,
+        description="URL for the footer link.",
+    )

--- a/mucgpt-core-service/app/api/api_models.py
+++ b/mucgpt-core-service/app/api/api_models.py
@@ -413,3 +413,7 @@ class ConfigResponse(BaseModel):
         None,
         description="URL for the footer link.",
     )
+    footer_label: str | None = Field(
+        None,
+        description="Label for the footer link.",
+    )

--- a/mucgpt-core-service/app/api/routers/system_router.py
+++ b/mucgpt-core-service/app/api/routers/system_router.py
@@ -28,6 +28,7 @@ async def get_config(user_info=Depends(authenticate_user)) -> ConfigResponse:
         assistant_version=settings.ASSISTANT_VERSION,
         document_processing_enabled=settings.PARSER_BACKEND != ParserBackendType.NONE,
         footer_link_url=settings.FOOTER_LINK_URL,
+        footer_label=settings.FOOTER_LABEL,
     )
 
     models = settings.MODELS

--- a/mucgpt-core-service/app/api/routers/system_router.py
+++ b/mucgpt-core-service/app/api/routers/system_router.py
@@ -27,6 +27,7 @@ async def get_config(user_info=Depends(authenticate_user)) -> ConfigResponse:
         frontend_version=settings.FRONTEND_VERSION,
         assistant_version=settings.ASSISTANT_VERSION,
         document_processing_enabled=settings.PARSER_BACKEND != ParserBackendType.NONE,
+        footer_link_url=settings.FOOTER_LINK_URL,
     )
 
     models = settings.MODELS

--- a/mucgpt-core-service/app/config/settings.py
+++ b/mucgpt-core-service/app/config/settings.py
@@ -386,6 +386,7 @@ class Settings(BaseSettings):
     APP_VERSION: str = "unknown"
     FRONTEND_VERSION: str = "unknown"
     ASSISTANT_VERSION: str = "unknown"
+    FOOTER_LINK_URL: str | None = None
 
     # Backend settings
     UNAUTHORIZED_USER_REDIRECT_URL: str = ""

--- a/mucgpt-core-service/app/config/settings.py
+++ b/mucgpt-core-service/app/config/settings.py
@@ -387,6 +387,7 @@ class Settings(BaseSettings):
     FRONTEND_VERSION: str = "unknown"
     ASSISTANT_VERSION: str = "unknown"
     FOOTER_LINK_URL: str | None = None
+    FOOTER_LABEL: str | None = None
 
     # Backend settings
     UNAUTHORIZED_USER_REDIRECT_URL: str = ""

--- a/mucgpt-core-service/config.yaml.example
+++ b/mucgpt-core-service/config.yaml.example
@@ -20,6 +20,7 @@ ALTERNATIVE_LOGO: false
 FRONTEND_VERSION: "unknown"
 ASSISTANT_VERSION: "unknown"
 FOOTER_LINK_URL: "https://ki.muenchen.de"
+FOOTER_LABEL: "DAICE"
 
 # Backend settings
 UNAUTHORIZED_USER_REDIRECT_URL: ""

--- a/mucgpt-core-service/config.yaml.example
+++ b/mucgpt-core-service/config.yaml.example
@@ -19,6 +19,7 @@ ENV_NAME: "MUCGPT"
 ALTERNATIVE_LOGO: false
 FRONTEND_VERSION: "unknown"
 ASSISTANT_VERSION: "unknown"
+FOOTER_LINK_URL: "https://ki.muenchen.de"
 
 # Backend settings
 UNAUTHORIZED_USER_REDIRECT_URL: ""

--- a/mucgpt-frontend/src/api/models.ts
+++ b/mucgpt-frontend/src/api/models.ts
@@ -58,6 +58,7 @@ export interface ApplicationConfig {
     frontend_version: string;
     assistant_version: string;
     document_processing_enabled: boolean;
+    footer_link_url?: string;
 }
 
 export interface Model {

--- a/mucgpt-frontend/src/api/models.ts
+++ b/mucgpt-frontend/src/api/models.ts
@@ -59,6 +59,7 @@ export interface ApplicationConfig {
     assistant_version: string;
     document_processing_enabled: boolean;
     footer_link_url?: string;
+    footer_label?: string;
 }
 
 export interface Model {

--- a/mucgpt-frontend/src/mocks/handlers.ts
+++ b/mucgpt-frontend/src/mocks/handlers.ts
@@ -126,7 +126,9 @@ const CONFIG_RESPONSE: ApplicationConfig = {
     core_version: "0.0.1",
     frontend_version: "0.0.1",
     assistant_version: "0.0.1",
-    document_processing_enabled: true
+    document_processing_enabled: true,
+    footer_link_url: "https://ki.muenchen.de",
+    footer_label: "DAICE"
 };
 
 const DYNAMIC_ASSISTANTS: AssistantCreateResponse[] = buildAssistantList(6);

--- a/mucgpt-frontend/src/pages/home/Home.tsx
+++ b/mucgpt-frontend/src/pages/home/Home.tsx
@@ -404,13 +404,8 @@ const Home = () => {
                         <div className={styles.footerCenterBlock}>
                             <div className={styles.footerCompanyBlock}>
                                 <span>{t("common.footer_credit", "Made with ❤️ & ☕ by")}</span>{" "}
-                                <a
-                                    href={footerLinkHref}
-                                    target="_blank"
-                                    rel="noreferrer noopener"
-                                    className={styles.footerCompanyLink}
-                                >
-                                    DAICE
+                                <a href={footerLinkHref} target="_blank" rel="noreferrer noopener" className={styles.footerCompanyLink}>
+                                    {config?.footer_label || "DAICE"}
                                 </a>
                             </div>
                         </div>

--- a/mucgpt-frontend/src/pages/home/Home.tsx
+++ b/mucgpt-frontend/src/pages/home/Home.tsx
@@ -286,6 +286,13 @@ const Home = () => {
     const sectionHeading = t("home.assistants");
     const sectionLabel = mode === "recent" ? t("home.last_used") : t("home.recommended");
 
+    const footerLinkHref = useMemo(() => {
+        const candidate = config?.footer_link_url?.trim();
+        if (!candidate) return "https://ki.muenchen.de";
+        if (/^https?:\/\//i.test(candidate) || candidate.startsWith("/")) return candidate;
+        return "https://ki.muenchen.de";
+    }, [config?.footer_link_url]);
+
     return (
         <div className={styles.pageContainer}>
             <section className={styles.chatstartercontainer} aria-labelledby="chat-header">
@@ -398,9 +405,9 @@ const Home = () => {
                             <div className={styles.footerCompanyBlock}>
                                 <span>{t("common.footer_credit", "Made with ❤️ & ☕ by")}</span>{" "}
                                 <a
-                                    href={config?.footer_link_url || "https://ki.muenchen.de"}
+                                    href={footerLinkHref}
                                     target="_blank"
-                                    rel="noreferrer"
+                                    rel="noreferrer noopener"
                                     className={styles.footerCompanyLink}
                                 >
                                     DAICE

--- a/mucgpt-frontend/src/pages/home/Home.tsx
+++ b/mucgpt-frontend/src/pages/home/Home.tsx
@@ -397,8 +397,13 @@ const Home = () => {
                         <div className={styles.footerCenterBlock}>
                             <div className={styles.footerCompanyBlock}>
                                 <span>{t("common.footer_credit", "Made with ❤️ & ☕ by")}</span>{" "}
-                                <a href="https://ki.muenchen.de" target="_blank" rel="noreferrer" className={styles.footerCompanyLink}>
-                                    KIES
+                                <a
+                                    href={config?.footer_link_url || "https://ki.muenchen.de"}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className={styles.footerCompanyLink}
+                                >
+                                    DAICE
                                 </a>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
changed department name to "DAICE" & made link configurable

## Why
link is configurable to use "intern" links to the department
higher-level department

## Validation
How was this verified?
- [ ] Automated tests
- [ ] Manual verification
- [x] Not applicable

## UI Changes (If applicable)
*Please add screenshots or screencasts of any visual changes.*

## Change Areas
- [x] Frontend
- [x] Core service
- [ ] Assistant service
- [ ] Migrations / DB
- [ ] Infrastructure / Docker / Compose / Keycloak
- [ ] CI / CD
- [ ] Docs

## Risks / Rollout Notes
links has to be configured when deployed

## References
Related: #
Closes: #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Footer link and footer label are now configurable via application settings; configured values are used when provided, with sensible defaults.

* **Bug Fixes / Improvements**
  * Outbound footer link input is trimmed and restricted to safe URL forms; external links now include safer rel attributes.
* **Testing / Mocks**
  * Mock backend responses updated to include the new footer fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->