### PR TITLE
fix: add request context to populate assistant id to middleware

### DIFF
--- a/mucgpt-core-service/app/agent/middleware.py
+++ b/mucgpt-core-service/app/agent/middleware.py
@@ -1,4 +1,5 @@
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import Any
 from xml.sax.saxutils import escape, quoteattr
 
@@ -15,6 +16,7 @@ from langchain_core.messages import (
     ToolMessage,
 )
 from langfuse.langchain import CallbackHandler as LFCallbackHandler
+from langgraph.config import get_config as get_runtime_config
 from langgraph.types import Command
 
 from agent.state_models.default_state import DefaultAgentState
@@ -23,6 +25,11 @@ from config.langfuse_provider import LangfuseProvider
 from core.logtools import getLogger
 
 logger = getLogger(name="agent-middleware")
+
+
+@dataclass
+class RequestContext:
+    assistant_id: str | None = None
 
 
 def _make_scoped_callbacks() -> list:
@@ -188,6 +195,26 @@ def _inject_data_sources(
     return messages_copy
 
 
+def _get_assistant_id_from_request(request: ModelRequest) -> str | None:
+    """Return the assistant id from runtime context or active config."""
+    runtime_context = getattr(getattr(request, "runtime", None), "context", None)
+    if isinstance(runtime_context, RequestContext):
+        return runtime_context.assistant_id
+    if isinstance(runtime_context, dict):
+        assistant_id = runtime_context.get("assistant_id")
+        if assistant_id:
+            return str(assistant_id)
+
+    try:
+        config = get_runtime_config() or {}
+    except Exception:
+        return None
+
+    configurable = config.get("configurable", {})
+    assistant_id = configurable.get("assistant_id")
+    return str(assistant_id) if assistant_id else None
+
+
 # TODO:
 # - Ensure the frontend is stateful and can send the current scope in the request
 class ContextMiddleware(AgentMiddleware):
@@ -225,7 +252,10 @@ class ContextMiddleware(AgentMiddleware):
         request = request.override(tools=policy.select_tools(request))
         logger.info(f"selected Tools: {len(request.tools or [])}")
         _annotate_span_with_policy_state(policy, request.state, self.state_schema)
-        request = policy.modify_system_message(request)
+
+        assistant_id = _get_assistant_id_from_request(request)
+        if not assistant_id:
+            request = policy.modify_system_message(request)
 
         state_data_sources = (
             request.state.get("data_sources", [])
@@ -256,7 +286,10 @@ class ContextMiddleware(AgentMiddleware):
         )
         logger.info(f"selected Tools: {len(request.tools or [])}")
         _annotate_span_with_policy_state(policy, request.state, self.state_schema)
-        request = await policy.amodify_system_message(request)
+
+        assistant_id = _get_assistant_id_from_request(request)
+        if not assistant_id:
+            request = await policy.amodify_system_message(request)
 
         state_data_sources = (
             request.state.get("data_sources", [])

--- a/mucgpt-core-service/app/agent/react_agent.py
+++ b/mucgpt-core-service/app/agent/react_agent.py
@@ -76,7 +76,7 @@ class _ConfiguredLangChainAgentGraph:
 
     def _prepare_run(
         self, input_data: dict[str, Any], config: RunnableConfig | None
-    ) -> tuple[Any, list[Any], list[BaseTool], type[DefaultAgentState], list[dict[str, Any]] | None]:
+    ) -> tuple[Any, list[Any], list[BaseTool], type[DefaultAgentState], list[dict[str, Any]] | None, RequestContext]:
         configurable = config.get("configurable", {}) if config else {}
         user_info = cast(AuthenticationResult | None, configurable.get("user_info"))
         if not user_info:

--- a/mucgpt-core-service/app/agent/react_agent.py
+++ b/mucgpt-core-service/app/agent/react_agent.py
@@ -7,7 +7,7 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.runnables.config import merge_configs
 from langchain_core.tools.base import BaseTool
 
-from agent.middleware import ContextMiddleware, ToolErrorMiddleware
+from agent.middleware import ContextMiddleware, RequestContext, ToolErrorMiddleware
 from agent.state_models.default_state import DefaultAgentState
 from agent.tools.mcp import McpBearerAuthProvider
 from agent.tools.tools import ToolCollection, select_agent_state_schema
@@ -57,6 +57,7 @@ class _ConfiguredLangChainAgentGraph:
             system_prompt=DEFAULT_INSTRUCTIONS,
             debug=self.debug,
             state_schema=initial_state_schema,
+            context_schema=RequestContext,
         )
 
     @staticmethod
@@ -85,6 +86,7 @@ class _ConfiguredLangChainAgentGraph:
         extra_body = configurable.get("llm_extra_body")
         enabled_tools = configurable.get("enabled_tools")
         selected_llm = configurable.get("llm")
+        assistant_id = configurable.get("assistant_id")
 
         # Keep MCP auth token map up-to-date for forwarded auth providers.
         McpBearerAuthProvider.set_token(user_info.user_id, user_info.token)
@@ -110,7 +112,11 @@ class _ConfiguredLangChainAgentGraph:
         configurable = config.get("configurable", {}) if config else {}
         data_sources = configurable.get("data_sources", [])
 
-        return model, messages, tools_to_use, agent_state_schema, data_sources
+        request_context = RequestContext(
+            assistant_id=str(assistant_id) if assistant_id else None
+        )
+
+        return model, messages, tools_to_use, agent_state_schema, data_sources, request_context
 
     async def astream(
         self,
@@ -120,7 +126,7 @@ class _ConfiguredLangChainAgentGraph:
         config: RunnableConfig | None = None,
         **kwargs,
     ):
-        model, messages, tools_to_use, agent_state_schema, data_sources = (
+        model, messages, tools_to_use, agent_state_schema, data_sources, request_context = (
             self._prepare_run(input_data, config)
         )
 
@@ -156,6 +162,7 @@ class _ConfiguredLangChainAgentGraph:
                 else None,
                 debug=self.debug,
                 state_schema=agent_state_schema,
+                context_schema=RequestContext,
             )
 
         input_payload = {"messages": messages}
@@ -166,6 +173,7 @@ class _ConfiguredLangChainAgentGraph:
             input_payload,
             stream_mode=stream_mode,
             config=config,
+            context=request_context,
             **kwargs,
         ):
             yield item
@@ -177,7 +185,7 @@ class _ConfiguredLangChainAgentGraph:
         config: RunnableConfig | None = None,
         **kwargs,
     ):
-        model, messages, tools_to_use, agent_state_schema, data_sources = (
+        model, messages, tools_to_use, agent_state_schema, data_sources, request_context = (
             self._prepare_run(input_data, config)
         )
 
@@ -211,13 +219,16 @@ class _ConfiguredLangChainAgentGraph:
                 else None,
                 debug=self.debug,
                 state_schema=agent_state_schema,
+                context_schema=RequestContext,
             )
 
         input_payload = {"messages": messages}
         if data_sources:
             input_payload["data_sources"] = data_sources  # type: ignore
 
-        return await active_agent.ainvoke(input_payload, config=config, **kwargs)
+        return await active_agent.ainvoke(
+            input_payload, config=config, context=request_context, **kwargs
+        )
 
 
 class MUCGPTReActAgent:


### PR DESCRIPTION
…aintain assistant systemprompt


## Summary
populate assistant id to middleware via context schema to ensure that the assistant prompt defined in the frontend is used over the internal prompt pool

## Why
Faster debugging

## Validation
How was this verified?
- [ ] Automated tests
- [x] Manual verification
- [ ] Not applicable


## Change Areas
- [ ] Frontend
- [x] Core service
- [ ] Assistant service
- [ ] Migrations / DB
- [ ] Infrastructure / Docker / Compose / Keycloak
- [ ] CI / CD
- [ ] Docs




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Assistants are now identified at runtime, with system message modifications applied conditionally based on whether an assigned identity is present, enabling different handling for identified vs. unidentified assistants.
  * Request context is properly maintained throughout all agent operations, ensuring consistent identity and context propagation across every invocation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/it-at-m/mucgpt/pull/967?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->