### PR TITLE
fixed refocus on every keytroke in chatinput

### DIFF
--- a/mucgpt-frontend/src/components/QuestionInput/QuestionInput.tsx
+++ b/mucgpt-frontend/src/components/QuestionInput/QuestionInput.tsx
@@ -100,10 +100,6 @@ export const QuestionInput = ({
                 return;
             }
 
-            const hadFocus = document.activeElement === textarea;
-            const selectionStart = textarea.selectionStart;
-            const selectionEnd = textarea.selectionEnd;
-
             textarea.style.height = "auto";
 
             const maxHeight = 200;
@@ -112,11 +108,6 @@ export const QuestionInput = ({
 
             textarea.style.height = `${newHeight}px`;
             textarea.style.overflowY = scrollHeight > maxHeight ? "auto" : "hidden";
-
-            if (hadFocus) {
-                textarea.focus();
-                textarea.setSelectionRange(selectionStart, selectionEnd);
-            }
         };
 
         resizeTextarea();


### PR DESCRIPTION
## Summary
What changed?

Removed the forced textarea refocus and cursor selection restore during chat input auto-resize.

## Why
Why is this change needed?

The chat input resized on every question change and explicitly called `focus()` again when the textarea was active. This could cause unwanted scroll/focus side effects while typing in the chat input. The resize logic now only updates the textarea height and overflow state.


## Validation
How was this verified?
- [ ] Automated tests
- [ ] Manual verification
- [ ] Not applicable

## UI Changes (If applicable)
*Please add screenshots or screencasts of any visual changes.*

## Change Areas
- [x] Frontend
- [ ] Core service
- [ ] Assistant service
- [ ] Migrations / DB
- [ ] Infrastructure / Docker / Compose / Keycloak
- [ ] CI / CD
- [ ] Docs

## Risks / Rollout Notes
Is there anything reviewers or operators should pay attention to?
*Examples: breaking changes, config changes, migration order, deployment considerations, rollback concerns.*

## References
Related: #
Closes: #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved question input textarea behavior by streamlining the auto-resize functionality. The textarea now resizes more smoothly during typing without unnecessary focus interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->