### PR TITLE
Rename help button to FAQ button

### DIFF
--- a/mucgpt-frontend/src/components/FaqButton/FaqButton.module.css
+++ b/mucgpt-frontend/src/components/FaqButton/FaqButton.module.css
@@ -1,8 +1,8 @@
-.helpButton {
+.faqButton {
     color: var(--colorNeutralForeground1) !important;
 }
 
-.helpButton:hover {
+.faqButton:hover {
     background-color: var(--colorNeutralStroke2) !important;
 }
 

--- a/mucgpt-frontend/src/components/FaqButton/FaqButton.tsx
+++ b/mucgpt-frontend/src/components/FaqButton/FaqButton.tsx
@@ -2,17 +2,17 @@ import { Button } from "@fluentui/react-components";
 import { QuestionCircle24Regular } from "@fluentui/react-icons";
 import { useTranslation } from "react-i18next";
 
-import styles from "./HelpButton.module.css";
+import styles from "./FaqButton.module.css";
 
-interface HelpButtonProps {
+interface FaqButtonProps {
     url: string;
     label?: string;
 }
 
-export const HelpButton = ({ url, label }: HelpButtonProps) => {
+export const FaqButton = ({ url, label }: FaqButtonProps) => {
     const { t } = useTranslation();
 
-    const helpLabel = label || t("components.helpbutton.label", "Hilfe & FAQ");
+    const faqLabel = label || t("components.faqbutton.label", "Fragen & Antworten");
 
     return (
         <Button
@@ -22,12 +22,12 @@ export const HelpButton = ({ url, label }: HelpButtonProps) => {
             rel="noopener noreferrer"
             appearance={"subtle"}
             icon={<QuestionCircle24Regular className={styles.icon} />}
-            aria-label={t("components.helpbutton.aria_label", "Hilfe und FAQ öffnen")}
-            className={styles.helpButton}
+            aria-label={t("components.faqbutton.aria_label", "Fragen und Antworten öffnen")}
+            className={styles.faqButton}
         >
-            {helpLabel}
+            {faqLabel}
         </Button>
     );
 };
 
-export default HelpButton;
+export default FaqButton;

--- a/mucgpt-frontend/src/components/FaqButton/index.ts
+++ b/mucgpt-frontend/src/components/FaqButton/index.ts
@@ -1,0 +1,2 @@
+export { FaqButton } from "./FaqButton";
+export { default } from "./FaqButton";

--- a/mucgpt-frontend/src/components/HelpButton/index.ts
+++ b/mucgpt-frontend/src/components/HelpButton/index.ts
@@ -1,2 +1,0 @@
-export { HelpButton } from "./HelpButton";
-export { default } from "./HelpButton";

--- a/mucgpt-frontend/src/i18n.ts
+++ b/mucgpt-frontend/src/i18n.ts
@@ -202,10 +202,9 @@ i18n
                             aria_label: "Feedback per E-Mail senden",
                             label: "Feedback"
                         },
-                        helpbutton: {
-                            help: "Hilfe",
-                            label: "Hilfe & FAQ",
-                            aria_label: "Hilfe und FAQ öffnen"
+                        faqbutton: {
+                            label: "Fragen & Antworten",
+                            aria_label: "Fragen und Antworten öffnen"
                         },
                         theme_selector: {
                             theme_light: "Helles Design",
@@ -895,10 +894,9 @@ i18n
                             aria_label: "Send feedback via email",
                             label: "Feedback"
                         },
-                        helpbutton: {
-                            help: "Help",
-                            label: "Help & FAQ",
-                            aria_label: "Open help and FAQ"
+                        faqbutton: {
+                            label: "FAQ",
+                            aria_label: "Open FAQ"
                         },
                         theme_selector: {
                             theme_light: "Light theme",
@@ -1579,10 +1577,9 @@ i18n
                             aria_label: "Feedback per E-Mail schick'n",
                             label: "Feedback"
                         },
-                        helpbutton: {
-                            help: "Hilfe",
-                            label: "Hilfe & FAQ",
-                            aria_label: "Hilfe und FAQ aufmach'n"
+                        faqbutton: {
+                            label: "Frogn & Antwortn",
+                            aria_label: "Frogn und Antwortn aufmach'n"
                         },
                         theme_selector: {
                             theme_light: "Helles Design",
@@ -2260,10 +2257,9 @@ i18n
                             aria_label: "Envoyer des retours par e-mail",
                             label: "Feedback"
                         },
-                        helpbutton: {
-                            help: "Aide",
-                            label: "Aide & FAQ",
-                            aria_label: "Ouvrir l'aide et la FAQ"
+                        faqbutton: {
+                            label: "Questions et réponses",
+                            aria_label: "Ouvrir les questions et réponses"
                         },
                         theme_selector: {
                             theme_light: "Thème clair",
@@ -2941,10 +2937,9 @@ i18n
                             aria_label: "Надіслати відгук електронною поштою",
                             label: "Відгук"
                         },
-                        helpbutton: {
-                            help: "Допомога",
-                            label: "Допомога та FAQ",
-                            aria_label: "Відкрити допомогу та FAQ"
+                        faqbutton: {
+                            label: "Запитання та відповіді",
+                            aria_label: "Відкрити запитання та відповіді"
                         },
                         theme_selector: {
                             theme_light: "Світла тема",

--- a/mucgpt-frontend/src/pages/layout/Layout.tsx
+++ b/mucgpt-frontend/src/pages/layout/Layout.tsx
@@ -19,7 +19,7 @@ import { UserContextProvider } from "./UserContextProvider";
 import { LanguageSelector } from "../../components/LanguageSelector";
 import { ThemeSelector } from "../../components/ThemeSelector";
 import { FeedbackButton } from "../../components/FeedbackButton";
-import { HelpButton } from "../../components/HelpButton";
+import { FaqButton } from "../../components/FaqButton";
 import { configApi } from "../../api/core-client";
 import { ApiError } from "../../api/fetch-utils";
 import { useGlobalToastContext } from "../../components/GlobalToastHandler/GlobalToastContext";
@@ -109,7 +109,7 @@ const AppShell = ({ config, isLight, languagePreference, onLanguageSelectionChan
                 </div>
                 {faqUrl && (
                     <div className={styles.mobileUtilityRow}>
-                        <HelpButton url={faqUrl} label={t("components.helpbutton.help")} />
+                        <FaqButton url={faqUrl} label={t("components.faqbutton.label")} />
                     </div>
                 )}
             </div>


### PR DESCRIPTION
## Summary
Renamed the former Help button to FAQ / Fragen & Antworten across the frontend i18n resources and component naming.


## Why

## Validation
How was this verified?
- [ ] Automated tests
- [ ] Manual verification
- [ ] Not applicable

## UI Changes (If applicable)
*Please add screenshots or screencasts of any visual changes.*

## Change Areas
- [X] Frontend
- [ ] Core service
- [ ] Assistant service
- [ ] Migrations / DB
- [ ] Infrastructure / Docker / Compose / Keycloak
- [ ] CI / CD
- [ ] Docs

## Risks / Rollout Notes
Is there anything reviewers or operators should pay attention to?
*Examples: breaking changes, config changes, migration order, deployment considerations, rollback concerns.*

## References
Related: #
Closes: #1009


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Help button has been replaced with an FAQ button in the mobile utilities section for improved user access to frequently asked questions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->