### PR TITLE
✨ Soft-delete tombstones to stop cross-device chat resurrection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,7 +163,7 @@ stack/ca-bundle.crt
 stack/assistant.config.yaml
 stack/core.config.yaml
 mucgpt-assistant-service/debug_ldap.py
-mucgpt-core-service/issues/*
+
 
 # Personal Claude Code permissions (not shared)
 .claude/settings.local.json

--- a/CHAT_PERSISTENCE.md
+++ b/CHAT_PERSISTENCE.md
@@ -83,7 +83,10 @@ messages** via LangGraph's `add_messages` reducer and would require a per-turn
   - `GET    /v1/conversations` — list current user's conversations
   - `GET    /v1/conversations/{id}` — fetch one with messages
   - `PATCH  /v1/conversations/{id}` — update title / favorite (PATCH semantics)
-  - `DELETE /v1/conversations/{id}` — delete (cascades messages)
+  - `DELETE /v1/conversations/{id}` — **soft delete** (sets a `deleted_at`
+    tombstone; row + messages retained, see *Deletion tombstones* below)
+  - `GET    /v1/conversations/deleted?since=` — tombstone feed: ids the user
+    deleted (on any device), for cross-device deletion sync
   - `POST   /v1/conversations/{id}/messages` — append a message
   - `GET    /v1/conversations/{id}/state` — checkpoint state probe (returns
     `has_checkpoint=false` gracefully when no checkpointer is engaged)
@@ -135,12 +138,20 @@ messages** via LangGraph's `add_messages` reducer and would require a per-turn
   delete, **user isolation**, cross-user denial, monotonic sequencing, cascade delete.
 - `tests/integration/test_conversations_router.py` — router behavior.
 - `tests/integration/test_chat_persistence_e2e.py` — end-to-end: history syncs and
-  accumulates in the DB, an unknown `conversation_id` is auto-created, and the chat flow
-  does **not** engage the checkpointer.
+  accumulates in the DB, an unknown `conversation_id` is auto-created, the chat flow
+  does **not** engage the checkpointer, and a send to a **tombstoned**
+  `conversation_id` is rejected with 409 (the second resurrection vector) without
+  resurrecting the chat.
 - `tests/unit/test_agent_executor.py::TestChatGraphNeverCarriesCheckpointer` —
   regression guard: forces the per-request graph rebuild and asserts **no** chat graph is
   ever compiled with a checkpointer (prevents the `thread_id` error from recurring).
-- **Suite status: 89 passed, 5 skipped.**
+- `tests/unit/test_conversation_repo.py` — also covers tombstones: soft delete
+  retains the row/messages, idempotent delete, anti-resurrection guard, writes to
+  a tombstoned id fail closed, and `list_deleted_for_user` `since`-cursor.
+- `tests/integration/test_conversations_router.py` — also covers soft-delete →
+  404, `409` on re-creating a tombstoned id (writes nothing), and the
+  owner-scoped tombstone feed with `since`.
+- **Suite status: 100 passed, 5 skipped.**
 
 ---
 
@@ -199,9 +210,64 @@ MUCGPT_CORE_DB__NAME=mucgpt
 - **Rollback:** reverting the frontend leaves the new tables unused but harmless; there is
   no destructive migration.
 
+## Deletion tombstones (cross-device delete)
+
+Hard delete + the "push any local chat the backend is missing" reconcile used to
+combine into a **resurrection loop**: device A deletes chat *X*, device B still
+has *X* locally, B's next sync re-creates *X* on the backend, and A pulls it back
+— so deletes never stuck across devices. Deletion is now a **soft delete**:
+
+- `Conversation` carries a nullable `deleted_at`. `DELETE` stamps it instead of
+  removing the row (`NULL` = live, a timestamp = tombstoned). `delete()` is
+  idempotent and keeps the first timestamp.
+- All normal reads (`GET /{id}`, `GET /` list) **exclude tombstones**, so a
+  deleted chat returns **404** / is absent — 404 covers both "never existed" and
+  "deleted" (a deleted chat is just gone, not a distinct state).
+- **Re-creating a tombstoned id is rejected with `409 Conflict`** (body:
+  `{detail, conversation_id}`) — both on `POST /v1/conversations` and on the chat
+  completion auto-create path. The guard writes nothing, killing the resurrection
+  push at the source.
+- `GET /v1/conversations/deleted?since=<iso8601>` returns the caller's
+  tombstones (`{id, deleted_at}`, oldest-deleted first, owner-scoped). The
+  frontend `runSync` fetches it, **removes** those chats from IndexedDB, and
+  **excludes** them from the push set — so a delete on one device propagates and
+  no client can resurrect a chat it merely still caches. Clients may remember the
+  max applied `deleted_at` and pass it back as `since` for incremental sync.
+
+**Degraded path (accepted):** if the backend delete-mirror fails, the chat is
+already gone locally but its backend row is still live, so a later sync re-pulls
+it and the user can re-delete — a bounded reappearance, never silent data loss.
+
+### Production migration (existing DBs)
+
+`Base.metadata.create_all` only creates *missing tables*; it will **not** add
+`deleted_at` to an existing `conversations` table. Fresh DBs (and the default
+local SQLite) get the column automatically. For an existing Postgres deployment,
+apply once before deploying the new code:
+
+```sql
+ALTER TABLE conversations ADD COLUMN deleted_at TIMESTAMPTZ NULL;
+```
+
+(SQLite: `ALTER TABLE conversations ADD COLUMN deleted_at TIMESTAMP NULL;`.)
+core-service has no Alembic yet; when it adopts one, add this as a revision.
+
+### Retention / pruning
+
+Tombstones accumulate forever otherwise. A retention sweep can hard-delete
+conversations (and their messages) whose `deleted_at` is older than a generous
+window (e.g. 30–90 days), by which point all realistically-online clients have
+reconciled. Trade-off: a client offline **longer** than the window won't see the
+tombstone and could re-push the chat — so prune the **row** only after the window
+(while the row survives, the `409` guard still blocks the push). Pruning is
+**manual for now** (no scheduled job); the timestamp column is what makes it
+possible later. Related: optimistic-concurrency (`#1068`) guards content
+overwrites and is independent of these existence tombstones.
+
 ## How it was verified
 
 - Automated: repository, router, and end-to-end persistence suites plus the
-  checkpointer regression guard (89 passed, 5 skipped).
+  checkpointer regression guard, plus the deletion-tombstone repo/router/feed
+  tests (100 passed, 5 skipped).
 - Manual: a chat created in one browser appears in the history of a second browser /
   private tab for the same logged-in user after rebuild.

--- a/mucgpt-core-service/app/api/api_models.py
+++ b/mucgpt-core-service/app/api/api_models.py
@@ -534,6 +534,25 @@ class AppendMessageRequest(BaseModel):
     )
 
 
+class DeletedConversation(BaseModel):
+    """Tombstone-feed item: a conversation id the user deleted, and when.
+
+    Clients only need the ``id`` to drop the local chat; ``deleted_at`` doubles
+    as the cursor for incremental sync (``GET /conversations/deleted?since=``).
+    """
+
+    id: str
+    deleted_at: datetime
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ConversationConflict(BaseModel):
+    """409 body when re-creating a tombstoned (deleted) conversation id."""
+
+    detail: str
+    conversation_id: str
+
+
 class ConversationStateResponse(BaseModel):
     """Checkpointed LangGraph agent state for a conversation thread."""
 

--- a/mucgpt-core-service/app/api/routers/chat_router.py
+++ b/mucgpt-core-service/app/api/routers/chat_router.py
@@ -16,7 +16,10 @@ from config.settings import get_settings
 from core.auth import authenticate_user
 from core.auth_models import AuthenticationResult
 from core.logtools import getLogger
-from database.conversation_repo import ConversationRepository
+from database.conversation_repo import (
+    ConversationDeletedError,
+    ConversationRepository,
+)
 from database.session import get_db_session
 from init_app import init_agent
 
@@ -120,13 +123,22 @@ async def chat_completions(
         repo = ConversationRepository(session)
         conversation = await repo.get_for_user(conversation_id, user_info.user_id)
         if conversation is None:
-            # First turn: auto-create under the client-supplied id.
-            await repo.create(
-                user_id=user_info.user_id,
-                conversation_id=conversation_id,
-                model=request.model,
-                assistant_id=request.assistant_id,
-            )
+            # First turn: auto-create under the client-supplied id. If that id
+            # is tombstoned (deleted on another device), the create guard
+            # refuses to resurrect it — surface 409 instead of a 500 so the
+            # client treats the chat as gone rather than retrying forever.
+            try:
+                await repo.create(
+                    user_id=user_info.user_id,
+                    conversation_id=conversation_id,
+                    model=request.model,
+                    assistant_id=request.assistant_id,
+                )
+            except ConversationDeletedError as exc:
+                raise HTTPException(
+                    status_code=409,
+                    detail="Conversation was deleted and cannot be recreated",
+                ) from exc
         # Sync the stored history to the (authoritative) request history,
         # including the incoming user turn, before invoking the agent.
         await repo.replace_messages(

--- a/mucgpt-core-service/app/api/routers/conversations_router.py
+++ b/mucgpt-core-service/app/api/routers/conversations_router.py
@@ -4,6 +4,8 @@ Conversations and their messages live in the backend database (see
 ``app/database``). All endpoints are owner-scoped via the authenticated user.
 """
 
+from datetime import datetime
+
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from langchain_core.runnables import RunnableConfig
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -11,16 +13,21 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api.api_models import (
     AppendMessageRequest,
     ChatCompletionMessage,
+    ConversationConflict,
     ConversationDetail,
     ConversationStateResponse,
     ConversationSummary,
     CreateConversationRequest,
+    DeletedConversation,
     UpdateConversationRequest,
 )
 from core.auth import authenticate_user
 from core.auth_models import AuthenticationResult
 from core.logtools import getLogger
-from database.conversation_repo import ConversationRepository
+from database.conversation_repo import (
+    ConversationDeletedError,
+    ConversationRepository,
+)
 from database.models import Conversation
 from database.session import get_db_session
 from init_app import init_agent
@@ -76,15 +83,27 @@ async def create_conversation(
     session: AsyncSession = Depends(get_db_session),
 ) -> ConversationDetail:
     repo = ConversationRepository(session)
-    conversation = await repo.create(
-        user_id=user_info.user_id,
-        conversation_id=request.id,
-        title=request.title,
-        assistant_id=request.assistant_id,
-        model=request.model,
-        config=request.config,
-        messages=[(m.role, m.content) for m in request.messages],
-    )
+    try:
+        conversation = await repo.create(
+            user_id=user_info.user_id,
+            conversation_id=request.id,
+            title=request.title,
+            assistant_id=request.assistant_id,
+            model=request.model,
+            config=request.config,
+            messages=[(m.role, m.content) for m in request.messages],
+        )
+    except ConversationDeletedError as exc:
+        # Re-creating a tombstoned id is a lost race with a delete: 409 Conflict
+        # (the id is taken-and-deleted). The guard wrote nothing, so we must not
+        # commit — leave the rollback to the session dependency teardown.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=ConversationConflict(
+                detail="Conversation was deleted and cannot be recreated",
+                conversation_id=exc.conversation_id,
+            ).model_dump(),
+        ) from exc
     await session.commit()
     await session.refresh(conversation)
     return _to_detail(conversation)
@@ -105,6 +124,31 @@ async def list_conversations(
 
 
 @router.get(
+    "/deleted",
+    response_model=list[DeletedConversation],
+    summary="List the current user's deleted-conversation tombstones",
+)
+async def list_deleted_conversations(
+    since: datetime | None = None,
+    user_info: AuthenticationResult = Depends(authenticate_user),
+    session: AsyncSession = Depends(get_db_session),
+) -> list[DeletedConversation]:
+    """Tombstone feed: ids the user deleted (on any device), oldest first.
+
+    Clients reconcile by dropping these ids locally instead of re-pushing them,
+    which is how a delete on one device propagates to another. Remember the max
+    ``deleted_at`` applied and pass it back as ``since`` for incremental sync;
+    with no ``since`` the full current tombstone set is returned.
+
+    Registered before ``/{conversation_id}`` so "deleted" is not captured as a
+    conversation id by the path parameter.
+    """
+    repo = ConversationRepository(session)
+    deleted = await repo.list_deleted_for_user(user_info.user_id, since)
+    return [DeletedConversation.model_validate(c) for c in deleted]
+
+
+@router.get(
     "/{conversation_id}",
     response_model=ConversationDetail,
     summary="Get a conversation with its messages",
@@ -117,6 +161,9 @@ async def get_conversation(
     repo = ConversationRepository(session)
     conversation = await repo.get_for_user(conversation_id, user_info.user_id)
     if conversation is None:
+        # 404 covers both "never existed" and "deleted" (tombstoned): a deleted
+        # chat reads as gone, not as a distinct state. Only GET /deleted exposes
+        # tombstones, and only as ids to reconcile away.
         raise HTTPException(status_code=404, detail="Conversation not found")
     return _to_detail(conversation)
 

--- a/mucgpt-core-service/app/database/conversation_repo.py
+++ b/mucgpt-core-service/app/database/conversation_repo.py
@@ -7,6 +7,7 @@ user's conversation, regardless of the id supplied in the request path.
 from __future__ import annotations
 
 from collections.abc import Iterable
+from datetime import datetime
 
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
@@ -17,6 +18,19 @@ from database.models import Conversation, Message
 # How many times append_message recomputes the next sequence and retries when a
 # concurrent writer wins the race for the same (conversation_id, sequence).
 _APPEND_MAX_ATTEMPTS = 5
+
+
+class ConversationDeletedError(Exception):
+    """Raised when a create targets an id that is already tombstoned.
+
+    A deleted conversation must not be resurrected by a client that still
+    caches it (the cross-device deletion loop). Re-creating a tombstoned id is
+    rejected at the source instead; the router maps this to HTTP 409.
+    """
+
+    def __init__(self, conversation_id: str):
+        self.conversation_id = conversation_id
+        super().__init__(f"Conversation {conversation_id!r} was deleted")
 
 
 class ConversationRepository:
@@ -39,7 +53,17 @@ class ConversationRepository:
         ``conversation_id`` lets the caller supply the primary key (e.g. a
         client-generated UUID so the same id is used end-to-end). When omitted
         the model's default UUID is generated.
+
+        Anti-resurrection: if the caller supplies an id that is already
+        tombstoned (deleted), the create is rejected with
+        ``ConversationDeletedError`` instead of inserting — a client that still
+        caches a deleted chat cannot bring it back. A live duplicate id keeps
+        today's behavior (the existing row's primary-key constraint applies).
         """
+        if conversation_id:
+            existing = await self._get_any(conversation_id, user_id)
+            if existing is not None and existing.deleted_at is not None:
+                raise ConversationDeletedError(conversation_id)
         conversation = Conversation(
             user_id=user_id,
             title=title,
@@ -65,10 +89,17 @@ class ConversationRepository:
         return conversation
 
     async def list_for_user(self, user_id: str) -> list[Conversation]:
-        """Return the user's conversations, most-recently-updated first."""
+        """Return the user's live conversations, most-recently-updated first.
+
+        Tombstoned (soft-deleted) conversations are excluded so a deleted chat
+        never reappears in the normal list.
+        """
         result = await self.session.execute(
             select(Conversation)
-            .where(Conversation.user_id == user_id)
+            .where(
+                Conversation.user_id == user_id,
+                Conversation.deleted_at.is_(None),
+            )
             .order_by(Conversation.updated_at.desc())
         )
         return list(result.scalars().all())
@@ -76,14 +107,35 @@ class ConversationRepository:
     async def get_for_user(
         self, conversation_id: str, user_id: str
     ) -> Conversation | None:
-        """Return the conversation (with messages) only if owned by user_id."""
+        """Return the live conversation (with messages) only if owned by user_id.
+
+        A tombstoned conversation reads as ``None`` (callers treat that as 404),
+        so soft-deleted chats are invisible to every normal read/write path.
+        """
+        result = await self.session.execute(
+            select(Conversation).where(
+                Conversation.id == conversation_id,
+                Conversation.user_id == user_id,
+                Conversation.deleted_at.is_(None),
+            )
+        )
+        # messages are eager-loaded via the relationship's lazy="selectin".
+        return result.scalars().first()
+
+    async def _get_any(
+        self, conversation_id: str, user_id: str
+    ) -> Conversation | None:
+        """Return the owned conversation **including** a tombstoned one.
+
+        Used by the resurrection guard (``create``) and idempotent ``delete``,
+        which both need to see soft-deleted rows that ``get_for_user`` hides.
+        """
         result = await self.session.execute(
             select(Conversation).where(
                 Conversation.id == conversation_id,
                 Conversation.user_id == user_id,
             )
         )
-        # messages are eager-loaded via the relationship's lazy="selectin".
         return result.scalars().first()
 
     async def update_meta(
@@ -101,13 +153,47 @@ class ConversationRepository:
         return conversation
 
     async def delete(self, conversation_id: str, user_id: str) -> bool:
-        """Delete the conversation (cascades to messages). Ownership enforced."""
-        conversation = await self.get_for_user(conversation_id, user_id)
+        """Soft-delete the conversation by stamping ``deleted_at``.
+
+        The row (and its messages) are retained so the deletion is a durable,
+        queryable fact — see ``list_deleted_for_user`` and the create-time
+        resurrection guard. Reads (``get_for_user``/``list_for_user``) then
+        exclude it, so callers still see a deleted chat as gone (404/absent).
+
+        Ownership is enforced and the operation is idempotent: deleting an
+        already-tombstoned chat is a no-op that returns ``True`` (the original
+        ``deleted_at`` is preserved for the retention/cursor semantics).
+        Returns ``False`` only when the conversation does not exist / is not
+        owned by the user.
+        """
+        conversation = await self._get_any(conversation_id, user_id)
         if conversation is None:
             return False
-        await self.session.delete(conversation)
-        await self.session.flush()
+        if conversation.deleted_at is None:
+            conversation.deleted_at = func.now()
+            await self.session.flush()
         return True
+
+    async def list_deleted_for_user(
+        self, user_id: str, since: datetime | None = None
+    ) -> list[Conversation]:
+        """Return the user's tombstoned conversations, oldest-deleted first.
+
+        Backs the tombstone feed: clients learn which ids were deleted (on any
+        device) so they can drop them locally instead of re-pushing them. When
+        ``since`` is given, only tombstones strictly newer than that cursor are
+        returned, so a client can sync incrementally by remembering the max
+        ``deleted_at`` it has already applied.
+        """
+        stmt = select(Conversation).where(
+            Conversation.user_id == user_id,
+            Conversation.deleted_at.is_not(None),
+        )
+        if since is not None:
+            stmt = stmt.where(Conversation.deleted_at > since)
+        stmt = stmt.order_by(Conversation.deleted_at)
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())
 
     async def replace_messages(
         self,

--- a/mucgpt-core-service/app/database/models.py
+++ b/mucgpt-core-service/app/database/models.py
@@ -56,6 +56,14 @@ class Conversation(Base):
         onupdate=_utcnow,
         nullable=False,
     )
+    # Soft-delete tombstone: NULL = live, a non-null timestamp = deleted (the
+    # value records *when*, used by the tombstone feed cursor and retention
+    # sweep). Existing/Postgres DBs need the explicit ALTER from the step-12
+    # migration; ``Base.metadata.create_all`` only creates missing tables, it
+    # will not add this column to an existing ``conversations`` table.
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
+    )
 
     messages: Mapped[list[Message]] = relationship(
         "Message",

--- a/mucgpt-core-service/roadmaps/chat-persistence/01-deps-and-db-settings.md
+++ b/mucgpt-core-service/roadmaps/chat-persistence/01-deps-and-db-settings.md
@@ -1,0 +1,39 @@
+# 01 — Add DB dependencies + DB settings config
+
+**Milestone:** M1 — Foundations  ·  **Depends on:** —  ·  **Size:** S
+
+## Context
+Core service currently has no database layer (`grep` of `pyproject.toml` shows only
+`langgraph>=1.1.6`, no SQLAlchemy). We need an async DB stack that defaults to SQLite
+(zero-infra, test-friendly) and can switch to Postgres in prod, matching
+`mucgpt-assistant-service`.
+
+## Scope
+**In:** add dependencies; add a `DB` settings section; document config.
+**Out:** session/engine code (issue 02), models (03).
+
+## Implementation
+1. `mucgpt-core-service/pyproject.toml` — add to `dependencies`:
+   - `sqlalchemy[asyncio]>=2.0`
+   - `aiosqlite>=0.20`            (SQLite async driver — default)
+   - `asyncpg>=0.29`              (Postgres async driver — prod)
+   - `langgraph-checkpoint-sqlite>=2.0`  (used by issue 08; grouped here so deps land once)
+   - (prod-only, can defer) `langgraph-checkpoint-postgres`
+2. `app/config/settings.py` — add a `DBConfig(BaseModel)` and a `DB` field on `Settings`:
+   - `backend: Literal["sqlite", "postgres"] = "sqlite"`
+   - `sqlite_path: str = "./data/mucgpt_chat.db"`
+   - `HOST/PORT/NAME/USER/PASSWORD(SecretStr)/SCHEMA` for postgres (mirror
+     `mucgpt-assistant-service/app/config/settings.py`)
+   - Follow the existing pydantic-settings + YAML source pattern already in this file.
+3. `mucgpt-core-service/config.yaml.example` — add a commented `db:` block (sqlite default +
+   postgres example).
+4. Ensure the sqlite data dir is git-ignored (`data/`), and document env override
+   `MUCGPT_CORE_DB__BACKEND` etc.
+
+## Acceptance criteria
+- `uv sync` / install resolves with the new deps.
+- `get_settings().DB.backend == "sqlite"` by default; Postgres values load from YAML/env.
+- No behavior change to existing endpoints.
+
+## Notes
+Keep `DB` optional/defaulted so existing deployments without a `db:` block still boot.

--- a/mucgpt-core-service/roadmaps/chat-persistence/02-db-session-and-repository.md
+++ b/mucgpt-core-service/roadmaps/chat-persistence/02-db-session-and-repository.md
@@ -1,0 +1,42 @@
+# 02 — DB session factory + generic Repository
+
+**Milestone:** M1 — Foundations  ·  **Depends on:** 01  ·  **Size:** M
+
+## Context
+Mirror the async DB scaffolding from `mucgpt-assistant-service/app/database/` so core service
+gets a consistent, tested pattern: an async engine/session factory, a FastAPI
+`get_db_session` dependency, and a generic `Repository[ModelType]`.
+
+## Scope
+**In:** new `app/database/` package: `__init__.py`, `base.py` (declarative `Base`),
+`session.py`, `repo.py`. Engine selection by `settings.DB.backend`.
+**Out:** concrete models (03), table creation wiring into lifespan (done minimally here,
+extended in 03).
+
+## Implementation
+1. `app/database/base.py` — `Base = declarative_base()`.
+2. `app/database/session.py`:
+   - `create_database_url(settings)` returning either
+     `sqlite+aiosqlite:///<path>` or a Postgres `URL.create(...)` (copy the safe
+     direct-parameter approach from the assistant-service `session.py`).
+   - cached `get_engine_and_factory_direct(settings)` (`create_async_engine` +
+     `async_sessionmaker`). For SQLite pass `connect_args={"check_same_thread": False}`.
+   - `async def get_db_session(settings=Depends(get_settings)) -> AsyncGenerator[AsyncSession]`
+     with rollback-on-error (port the structure, drop the assistant-service's verbose
+     Postgres-specific logging).
+   - `async def init_db()` — `async with engine.begin() as conn: await conn.run_sync(Base.metadata.create_all)`
+     (so SQLite "just works"; Postgres prod uses Alembic — see issue 03 notes).
+3. `app/database/repo.py` — copy the generic `Repository[ModelType: Base]`
+   (`create/get/get_all/update/delete`) from
+   `mucgpt-assistant-service/app/database/repo.py` verbatim (it's storage-agnostic).
+
+## Acceptance criteria
+- With `DB.backend=sqlite`, a session can be opened and `init_db()` creates tables (verified
+  in issue 12 against an in-memory `sqlite+aiosqlite:///:memory:`).
+- `get_db_session` is injectable in routers and overridable in tests via
+  `api_app.dependency_overrides`.
+
+## Notes
+Import `Base` from `app/database/base.py` everywhere (not from a models module) to avoid
+circular imports — assistant-service defines `Base` inside `database_models.py`; we split it
+out because both checkpointer and models will import it.

--- a/mucgpt-core-service/roadmaps/chat-persistence/03-db-models-conversation-message.md
+++ b/mucgpt-core-service/roadmaps/chat-persistence/03-db-models-conversation-message.md
@@ -1,0 +1,48 @@
+# 03 — `Conversation` & `Message` ORM models
+
+**Milestone:** M1 — Foundations  ·  **Depends on:** 02  ·  **Size:** M
+
+## Context
+Define the persisted shape of a chat. The frontend's current shape lives in
+`mucgpt-frontend/src/service/storage.ts` (a chat = `{ id, name, favorite, messages[], config,
+_last_edited }`, each message `{ role, content, ... }`). Model the backend tables to cover
+that so the frontend can later swap IndexedDB → API with minimal contract changes.
+
+## Scope
+**In:** `app/database/models.py` with `Conversation` and `Message`.
+**Out:** repositories (05), API models (04).
+
+## Implementation
+`app/database/models.py` (import `Base` from `app/database/base.py`):
+
+- **`Conversation`**
+  - `id: str` PK — UUID string (also used as the LangGraph `thread_id`, issue 09)
+  - `user_id: str` (indexed) — owner; sourced from `AuthenticationResult.user_id`
+  - `title: str | None`
+  - `favorite: bool = False`
+  - `assistant_id: str | None` (matches `ChatCompletionRequest.assistant_id`)
+  - `model: str | None`, `config: JSON | None` (creativity/temperature/enabled_tools snapshot)
+  - `created_at`, `updated_at` (`DateTime`, server defaults; bump `updated_at` on append)
+  - `messages = relationship(..., back_populates="conversation", cascade="all, delete-orphan", order_by="Message.sequence")`
+- **`Message`**
+  - `id: int` PK autoincrement
+  - `conversation_id: str` FK → `conversations.id` `ondelete="CASCADE"` (indexed)
+  - `sequence: int` — per-conversation ordering (0,1,2,…)
+  - `role: str` — `system | user | assistant`
+  - `content: Text`
+  - `tool_calls: JSON | None` (preserve the frontend's `tool_calls` chunk shape)
+  - `created_at: DateTime`
+  - `UniqueConstraint("conversation_id", "sequence")`
+
+Register models so `Base.metadata.create_all` (issue 02 `init_db`) picks them up; call
+`init_db()` from `warmup_app()` in `app/init_app.py` when `DB.backend == "sqlite"`.
+
+## Acceptance criteria
+- Tables create cleanly on SQLite via `init_db()`.
+- Deleting a `Conversation` cascades to its `Message` rows.
+- `messages` come back ordered by `sequence`.
+
+## Notes
+- Postgres prod: add an Alembic migration (optional stretch issue). For hackathon/SQLite,
+  `create_all` is enough — note this explicitly in the PR so it isn't mistaken for prod-ready.
+- Keep `content` as `Text` (not `String(n)`) — chat messages are unbounded.

--- a/mucgpt-core-service/roadmaps/chat-persistence/04-conversation-api-models.md
+++ b/mucgpt-core-service/roadmaps/chat-persistence/04-conversation-api-models.md
@@ -1,0 +1,30 @@
+# 04 — Conversation/Message API (Pydantic) models
+
+**Milestone:** M2 — Chat store  ·  **Depends on:** 01  ·  **Size:** S
+
+## Context
+Routers need request/response schemas separate from ORM models. Existing API models live in
+`app/api/api_models.py` (e.g. `ChatCompletionMessage`, `ChatCompletionRequest`). Reuse
+`ChatCompletionMessage` for message payloads to stay consistent with `/chat/completions`.
+
+## Scope
+**In:** Pydantic models for conversation CRUD.
+**Out:** router logic (06).
+
+## Implementation
+Add to `app/api/api_models.py` (or a new `app/api/conversation_models.py`):
+
+- `ConversationSummary` — `id, title, favorite, assistant_id, model, created_at, updated_at`
+  (list view, no messages).
+- `ConversationDetail` — `ConversationSummary` + `messages: list[ChatCompletionMessage]`.
+- `CreateConversationRequest` — `title: str | None`, `assistant_id: str | None`,
+  `model: str | None`, optional initial `messages: list[ChatCompletionMessage] = []`.
+- `UpdateConversationRequest` — `title: str | None`, `favorite: bool | None` (PATCH semantics).
+- `AppendMessageRequest` — a single `ChatCompletionMessage`.
+
+Use `model_config = ConfigDict(from_attributes=True)` so responses can be built directly from
+ORM rows.
+
+## Acceptance criteria
+- Schemas serialize ORM rows (`ConversationDetail.model_validate(orm_conversation)`).
+- OpenAPI docs render the new schemas under the Conversations tag (added in 06).

--- a/mucgpt-core-service/roadmaps/chat-persistence/05-conversation-repository.md
+++ b/mucgpt-core-service/roadmaps/chat-persistence/05-conversation-repository.md
@@ -1,0 +1,33 @@
+# 05 — `ConversationRepository`
+
+**Milestone:** M2 — Chat store  ·  **Depends on:** 03  ·  **Size:** M
+
+## Context
+The generic `Repository` (issue 02) covers basic CRUD by id. Conversations need owner-scoped
+queries, eager-loaded messages, and atomic message append with correct `sequence`.
+
+## Scope
+**In:** `app/database/conversation_repo.py` with a `ConversationRepository`.
+**Out:** HTTP layer (06).
+
+## Implementation
+`ConversationRepository(session: AsyncSession)` methods:
+
+- `create(user_id, title=None, assistant_id=None, model=None, config=None, messages=[]) -> Conversation`
+  — insert conversation; if initial messages provided, insert them with sequences `0..n`.
+- `list_for_user(user_id) -> list[Conversation]` — summary rows, ordered by `updated_at desc`,
+  **without** loading messages (use `selectinload` only in `get`).
+- `get_for_user(conversation_id, user_id) -> Conversation | None`
+  — eager-load `messages` via `selectinload(Conversation.messages)`; returns `None` if not
+  owned by `user_id` (enforce ownership in the query — never trust the path param alone).
+- `update_meta(conversation_id, user_id, **fields) -> Conversation | None` — title/favorite.
+- `delete(conversation_id, user_id) -> bool` — cascade handles messages.
+- `append_message(conversation_id, user_id, role, content, tool_calls=None) -> Message`
+  — compute next `sequence` (`SELECT max(sequence)+1`), insert, bump `conversation.updated_at`.
+  Wrap in a transaction; rely on the `UniqueConstraint(conversation_id, sequence)` as a
+  concurrency backstop.
+
+## Acceptance criteria
+- Ownership is enforced in every read/write (a user cannot fetch another user's conversation).
+- `append_message` produces gap-free, monotonic sequences.
+- Covered by unit tests in issue 12.

--- a/mucgpt-core-service/roadmaps/chat-persistence/06-conversations-router-crud.md
+++ b/mucgpt-core-service/roadmaps/chat-persistence/06-conversations-router-crud.md
@@ -1,0 +1,35 @@
+# 06 — Conversations CRUD router
+
+**Milestone:** M2 — Chat store  ·  **Depends on:** 04, 05  ·  **Size:** M
+
+## Context
+Expose the chat store over HTTP, mirroring router conventions in
+`app/api/routers/chat_router.py` (APIRouter with `/v1` prefix, `Depends(authenticate_user)`).
+
+## Scope
+**In:** `app/api/routers/conversations_router.py` + mount in `app/backend.py`.
+**Out:** persisting `/chat/completions` turns (07).
+
+## Implementation
+1. `app/api/routers/conversations_router.py` — `APIRouter(prefix="/v1/conversations")`,
+   each endpoint depending on `authenticate_user` and `get_db_session`:
+   - `POST   /`            → create (body `CreateConversationRequest`) → `ConversationDetail`
+   - `GET    /`            → list owner's conversations → `list[ConversationSummary]`
+   - `GET    /{id}`        → `ConversationDetail` (404 if not owned)
+   - `PATCH  /{id}`        → update title/favorite → `ConversationSummary`
+   - `DELETE /{id}`        → 204
+   - `POST   /{id}/messages` → append one message → `ConversationDetail`
+   - Build a `ConversationRepository(session)` per request; pass `user_info.user_id`.
+   - **Commit** the session at the end of write handlers (the repo only `flush`es — match
+     assistant-service transaction style; commit in the router/dependency).
+2. `app/backend.py` — `api_app.include_router(conversations_router.router, tags=["Conversations"])`
+   and add a `"Conversations"` entry to `openapi_tags`.
+
+## Acceptance criteria
+- Full CRUD works against SQLite; 404 on cross-user access; 204 on delete.
+- Endpoints visible in `/api/openapi.json` under the Conversations tag.
+- Covered by integration tests in issue 13.
+
+## Notes
+Decide commit boundary explicitly: simplest is to `await session.commit()` in each write
+handler after the repo call. Document it so issue 07 follows the same pattern.

--- a/mucgpt-core-service/roadmaps/chat-persistence/07-persist-chat-completions.md
+++ b/mucgpt-core-service/roadmaps/chat-persistence/07-persist-chat-completions.md
@@ -1,0 +1,42 @@
+# 07 — Persist turns in `/chat/completions`
+
+**Milestone:** M2 — Chat store  ·  **Depends on:** 06  ·  **Size:** M
+
+## Context
+`app/api/routers/chat_router.py::chat_completions` is currently stateless: it takes the full
+`messages` array each call and returns a completion. To store chats server-side we persist the
+incoming user turn and the produced assistant turn against a conversation.
+
+## Scope
+**In:** optional `conversation_id` on the chat request; persist user + assistant messages.
+**Out:** checkpointer/thread wiring (issue 09 — separate concern, can land independently).
+
+## Implementation
+1. `app/api/api_models.py` — add `conversation_id: str | None = None` to
+   `ChatCompletionRequest`. **Optional** → existing stateless clients unaffected.
+2. `chat_router.chat_completions`:
+   - Inject `session = Depends(get_db_session)`.
+   - If `conversation_id` is set:
+     - Validate ownership via `ConversationRepository.get_for_user`; 404 if missing.
+     - Persist the **last user message** from `request.messages` before invoking the agent.
+   - **Non-streaming:** after `run_without_streaming`, persist the assistant message, commit,
+     return as today.
+   - **Streaming:** accumulate streamed `content` deltas in the `sse_generator`; on
+     `finish_reason in {"stop","error"}`, persist the assembled assistant message and commit.
+     (Persist in a `finally`/after-loop block so a disconnect mid-stream still saves what
+     arrived.)
+   - If `conversation_id` is **not** set, behave exactly as today (no persistence).
+3. Optional convenience: if `conversation_id` omitted but client sends
+   `persist=true`, auto-create a conversation and return its id in a response header
+   (`X-Conversation-Id`). Mark as stretch.
+
+## Acceptance criteria
+- With a `conversation_id`, a non-streaming call appends exactly two messages
+  (user, assistant) in order.
+- A streaming call persists the fully-assembled assistant message once the stream ends.
+- Without `conversation_id`, response is byte-for-byte the current behavior.
+- Verified offline (fake model) in issue 14.
+
+## Notes
+Don't double-store: persist only the newly-arrived user turn, not the entire history the
+client replays. Define "last user message" precisely (the final `role=="user"` entry).

--- a/mucgpt-core-service/roadmaps/chat-persistence/08-checkpointer-provider.md
+++ b/mucgpt-core-service/roadmaps/chat-persistence/08-checkpointer-provider.md
@@ -1,0 +1,38 @@
+# 08 — Checkpointer provider
+
+**Milestone:** M3 — Agent state  ·  **Depends on:** 01  ·  **Size:** S
+
+## Context
+LangGraph's `create_agent` (used in `app/agent/react_agent.py:50`) accepts a `checkpointer`.
+Today none is passed → graph state is ephemeral. A checkpointer persists the full agent state
+(messages, tool steps) keyed by `thread_id`, enabling resume. `langgraph` is already a dep;
+`MemorySaver` is built in.
+
+## Scope
+**In:** `app/config/checkpointer_provider.py` exposing a singleton checkpointer chosen by
+config; init/teardown hooks.
+**Out:** wiring it into the agent (issue 09).
+
+## Implementation
+1. `app/config/checkpointer_provider.py` — `CheckpointerProvider` (mirror the
+   `ModelProvider` / `LangfuseProvider` singleton style):
+   - `init(settings)` selects:
+     - `MemorySaver()` when `DB.backend == "sqlite"` and no persistent path, **or** in tests
+       (default, no extra dep).
+     - `AsyncSqliteSaver.from_conn_string(<path>)` when a sqlite checkpoint path is configured.
+     - `AsyncPostgresSaver.from_conn_string(<url>)` when `DB.backend == "postgres"`.
+   - `get_checkpointer()` returns the instance (or `None` to disable — keeps the agent working
+     even if checkpointing is off).
+   - Manage async context (`__aenter__`/setup) for the async savers; call `.setup()` once.
+2. `app/init_app.py::warmup_app` — `await CheckpointerProvider.init(settings)`.
+   `destroy_app` — close it.
+
+## Acceptance criteria
+- `CheckpointerProvider.get_checkpointer()` returns a `MemorySaver` by default.
+- Switching config to a sqlite saver persists checkpoints to disk across restarts.
+- If checkpointer init fails, the service still boots (log + run without checkpointing).
+
+## Notes
+`AsyncSqliteSaver`/`AsyncPostgresSaver` live in `langgraph-checkpoint-sqlite` /
+`langgraph-checkpoint-postgres` (added in issue 01). `MemorySaver` needs nothing extra — so
+the test path has zero new runtime deps.

--- a/mucgpt-core-service/roadmaps/chat-persistence/09-wire-checkpointer-into-agent.md
+++ b/mucgpt-core-service/roadmaps/chat-persistence/09-wire-checkpointer-into-agent.md
@@ -1,0 +1,44 @@
+# 09 — Wire checkpointer + `thread_id` into the agent
+
+**Milestone:** M3 — Agent state  ·  **Depends on:** 08  ·  **Size:** M
+
+## Context
+`_ConfiguredLangChainAgentGraph` builds agents with `create_agent(...)` in
+`app/agent/react_agent.py` (lines 50 and 151/208 for the per-request rebuild). To persist
+graph state we pass the checkpointer at construction and a `thread_id` at run time. The
+`thread_id` is the `conversation_id` (issue 03/07), unifying layers A and B.
+
+## Scope
+**In:** pass checkpointer to all `create_agent` calls; thread `conversation_id` →
+`configurable.thread_id` through executor → agent.
+**Out:** the resume/get-state endpoint (issue 10).
+
+## Implementation
+1. `app/agent/react_agent.py`:
+   - Accept an optional `checkpointer` in `_ConfiguredLangChainAgentGraph.__init__` /
+     `MUCGPTReActAgent.__init__`; default to `CheckpointerProvider.get_checkpointer()`.
+   - Pass `checkpointer=self.checkpointer` to **every** `create_agent(...)` (the init one and
+     the two per-request rebuilds in `astream`/`ainvoke`).
+2. `app/agent/agent_executor.py`:
+   - Add `conversation_id: str | None` params to `run_with_streaming` /
+     `run_without_streaming`.
+   - When set, add `"thread_id": conversation_id` into the `configurable` dict of the
+     `RunnableConfig` (alongside the existing `llm`, `user_info`, … keys).
+   - Note: `run_without_streaming` currently calls `self.agent.model.invoke` directly
+     (bypassing the graph) — for checkpointed non-streaming, route through
+     `self.agent.graph.ainvoke` instead so state is recorded. Guard behind
+     `conversation_id is not None` to preserve current fast-path behavior.
+3. `app/api/routers/chat_router.py` — pass `conversation_id=request.conversation_id` into the
+   executor calls.
+4. `app/init_app.py::init_agent` — pass the provider's checkpointer into `MUCGPTReActAgent`.
+
+## Acceptance criteria
+- Two sequential `/chat/completions` calls with the same `conversation_id` show the second run
+  starting from persisted graph state (the checkpointer has prior messages for that thread).
+- Calls without a `conversation_id` keep the current stateless behavior.
+- Verified offline (fake model) in issue 14.
+
+## Notes
+LangGraph requires `thread_id` in `configurable` whenever a checkpointer is attached and you
+want persistence; without it the agent still runs but won't persist. Make the missing-id case
+a clean no-op, not an error.

--- a/mucgpt-core-service/roadmaps/chat-persistence/10-resume-and-state-endpoint.md
+++ b/mucgpt-core-service/roadmaps/chat-persistence/10-resume-and-state-endpoint.md
@@ -1,0 +1,31 @@
+# 10 — Resume / get-agent-state endpoint
+
+**Milestone:** M3 — Agent state  ·  **Depends on:** 09  ·  **Size:** S
+
+## Context
+With a checkpointer attached (issue 09), LangGraph can return the persisted state for a
+`thread_id` and resume an interrupted run. Expose this so the frontend can reload an in-flight
+agent conversation, not just stored messages.
+
+## Scope
+**In:** read-only state endpoint + (optional) explicit resume.
+**Out:** human-in-the-loop interrupt UI (future).
+
+## Implementation
+1. `app/api/routers/conversations_router.py` (or chat_router):
+   - `GET /v1/conversations/{id}/state` → returns the checkpointed graph state for
+     `thread_id == id` via `agent.graph.agent.aget_state(config)` where
+     `config = {"configurable": {"thread_id": id}}`. Shape the response to
+     `{messages, next, values}` (serialize messages to `ChatCompletionMessage`).
+   - 404 if the conversation isn't owned by the user; empty/`null` state if no checkpoint yet.
+2. (Optional) `POST /v1/conversations/{id}/resume` — re-invoke the agent with no new input
+   (`None`) for that `thread_id` to continue an interrupted run; stream like
+   `/chat/completions`.
+
+## Acceptance criteria
+- After a run with `conversation_id=X`, `GET .../X/state` returns the persisted messages.
+- Cross-user access is 404.
+- Verified offline in issue 14 (assert state after a fake-model run).
+
+## Notes
+Keep this additive and read-mostly; the resume POST is a stretch goal for the demo.

--- a/mucgpt-core-service/roadmaps/chat-persistence/11-fake-model-test-fixture.md
+++ b/mucgpt-core-service/roadmaps/chat-persistence/11-fake-model-test-fixture.md
@@ -1,0 +1,37 @@
+# 11 — Fake `BaseChatModel` test fixture (offline model)
+
+**Milestone:** M4 — Offline test proof  ·  **Depends on:** 01  ·  **Size:** S
+
+## Context
+The model endpoint is down. The LLM is abstracted behind `ModelProvider`
+(`app/config/model_provider.py`) and `init_app.ModelOptions.custom_model`
+(`app/init_app.py:43`). We inject a fake `BaseChatModel` so the entire agent + persistence
+flow runs with no network.
+
+## Scope
+**In:** reusable pytest fixtures providing a fake chat model and an `init_agent`/ModelProvider
+override.
+**Out:** the tests themselves (12–14).
+
+## Implementation
+1. `tests/conftest.py` (or extend `tests/integration/conftest.py`):
+   - `fake_chat_model` fixture returning
+     `langchain_core.language_models.fake_chat_models.GenericFakeChatModel(messages=iter([...]))`
+     — scripted `AIMessage`s; it supports `.stream()`/`.astream()` so streaming paths work.
+   - For tool-calling tests, script an `AIMessage` with `tool_calls=[...]` followed by a final
+     answer.
+2. Provide an override seam:
+   - Either monkeypatch `ModelProvider.get_model` to return the fake, **or** override the
+     `init_agent` dependency path. Prefer patching `ModelProvider.get_model` since
+     `init_agent` calls it directly (`app/init_app.py:105`).
+   - Add a `test_client_with_fake_model` fixture combining: `authenticate_user` override
+     (existing), `get_db_session` override (in-memory sqlite, issue 12), and the fake model.
+
+## Acceptance criteria
+- A test can drive `/chat/completions` (stream + non-stream) end-to-end with the fake model,
+  no network access.
+- The fixture is reusable across issues 12–14.
+
+## Notes
+`GenericFakeChatModel` yields deterministic output → assertions are stable. If a test needs
+multiple turns, re-create the fixture per call or pass a fresh message iterator.

--- a/mucgpt-core-service/roadmaps/chat-persistence/12-tests-db-unit.md
+++ b/mucgpt-core-service/roadmaps/chat-persistence/12-tests-db-unit.md
@@ -1,0 +1,26 @@
+# 12 — DB unit tests (models + repositories)
+
+**Milestone:** M4 — Offline test proof  ·  **Depends on:** 02, 03  ·  **Size:** M
+
+## Context
+Validate the persistence layer in isolation against in-memory SQLite — fast, no model, no
+network. Pattern follows `mucgpt-assistant-service/tests` (SQLAlchemy + aiosqlite).
+
+## Scope
+**In:** unit tests for `Conversation`/`Message` models and `ConversationRepository`.
+**Out:** HTTP-level tests (13).
+
+## Implementation
+1. `tests/unit/conftest.py` — `db_session` fixture: create an async engine on
+   `sqlite+aiosqlite:///:memory:`, `Base.metadata.create_all`, yield a session, dispose after.
+2. `tests/unit/test_conversation_repo.py`:
+   - create conversation (with and without initial messages)
+   - `list_for_user` ordering (updated_at desc) and ownership isolation
+   - `get_for_user` eager-loads messages in `sequence` order; returns `None` cross-user
+   - `append_message` → monotonic, gap-free sequences; bumps `updated_at`
+   - `delete` cascades to messages; cross-user delete returns `False`
+   - `update_meta` title/favorite
+
+## Acceptance criteria
+- `pytest tests/unit` passes offline.
+- Ownership isolation and cascade delete are explicitly asserted.

--- a/mucgpt-core-service/roadmaps/chat-persistence/13-tests-conversations-integration.md
+++ b/mucgpt-core-service/roadmaps/chat-persistence/13-tests-conversations-integration.md
@@ -1,0 +1,29 @@
+# 13 — Conversations CRUD integration tests
+
+**Milestone:** M4 — Offline test proof  ·  **Depends on:** 06  ·  **Size:** M
+
+## Context
+Exercise the conversations router through the FastAPI `TestClient`, reusing the established
+override pattern in `tests/integration/conftest.py` (`authenticate_user` override +
+`dependency_overrides`). No model endpoint involved — pure CRUD.
+
+## Scope
+**In:** HTTP tests for create/list/get/update/delete/append.
+**Out:** chat-flow persistence (14).
+
+## Implementation
+1. Extend `tests/integration/conftest.py`:
+   - Override `get_db_session` to yield a session bound to in-memory (or temp-file) SQLite with
+     tables created — so each test run is isolated.
+2. `tests/integration/test_conversations_router.py`:
+   - `POST /v1/conversations` → 200 + body; then `GET /v1/conversations` lists it.
+   - `GET /v1/conversations/{id}` returns messages in order; unknown id → 404.
+   - `PATCH` updates title/favorite.
+   - `POST /v1/conversations/{id}/messages` appends and returns updated detail.
+   - `DELETE` → 204, subsequent `GET` → 404.
+   - Cross-user: second authenticated user cannot read/delete the first user's conversation
+     (override `authenticate_user` with a different `user_id` in one test).
+
+## Acceptance criteria
+- `pytest tests/integration/test_conversations_router.py` passes offline.
+- Ownership (404 cross-user) asserted at the HTTP layer.

--- a/mucgpt-core-service/roadmaps/chat-persistence/14-tests-offline-e2e-and-checkpoint.md
+++ b/mucgpt-core-service/roadmaps/chat-persistence/14-tests-offline-e2e-and-checkpoint.md
@@ -1,0 +1,40 @@
+# 14 — Offline end-to-end + checkpoint resume test
+
+**Milestone:** M4 — Offline test proof  ·  **Depends on:** 07, 09, 11  ·  **Size:** M
+
+## Context
+The headline proof: with the **model endpoint down**, drive the full chat flow through a fake
+model and assert that both the app-level store (A) and the LangGraph checkpointer (B) persist
+and reload correctly. This is the acceptance test for the whole epic.
+
+## Scope
+**In:** end-to-end tests over `/chat/completions` with persistence + checkpoint assertions.
+**Out:** load/perf testing.
+
+## Implementation
+Use `test_client_with_fake_model` (issue 11) + sqlite `get_db_session` override (issue 13).
+
+1. `tests/integration/test_chat_persistence_e2e.py`:
+   - **Non-streaming persistence:** create a conversation; `POST /v1/chat/completions` with
+     `conversation_id`, `stream=false`, a user message; assert response; then
+     `GET /v1/conversations/{id}` shows `[user, assistant]` in order.
+   - **Streaming persistence:** same with `stream=true`; consume the SSE; assert the assembled
+     assistant message was persisted exactly once after `finish_reason=="stop"`.
+   - **Backward compat:** `POST` without `conversation_id` returns the normal response and
+     creates **no** rows.
+2. **Checkpoint resume (B):**
+   - With `conversation_id=X`, run one turn; then `GET /v1/conversations/{X}/state` (issue 10)
+     returns persisted graph messages.
+   - Run a second turn with the same id; assert the agent saw prior state (e.g. via the fake
+     model receiving accumulated messages, or state message count increasing).
+3. Assert **no outbound network**: the fake model is the only LLM; a real call would fail —
+   test passing proves offline operability.
+
+## Acceptance criteria
+- All e2e tests pass with no model endpoint / no network.
+- Demonstrates: store-and-reload (A), checkpoint persistence + resume (B), and unchanged
+  stateless behavior when `conversation_id` is absent.
+
+## Notes
+This file is the demo script for "it works with the model down" — keep assertions readable so
+it doubles as documentation.

--- a/mucgpt-core-service/roadmaps/chat-persistence/README.md
+++ b/mucgpt-core-service/roadmaps/chat-persistence/README.md
@@ -1,0 +1,87 @@
+# Epic: Backend chat persistence + agent state (offline-testable)
+
+## Goal
+
+Move chat storage from the browser (frontend IndexedDB, `mucgpt-frontend/src/service/storage.ts`)
+into the **core service** backend, and add **agent state persistence** so conversations can be
+stored, listed, reloaded, and resumed server-side.
+
+Two complementary layers (both in scope):
+
+- **A — App-level chat store.** New SQLAlchemy tables (`conversations`, `messages`) + CRUD
+  endpoints, mirroring the proven DB pattern in `mucgpt-assistant-service`. This is the
+  user-facing "my chats live in the backend" feature.
+- **B — LangGraph checkpointer.** Wire a checkpointer into `create_agent` keyed by a
+  `thread_id` (= conversation id). This is the "agentic" layer: full graph state
+  (messages, tool progress, scratchpad) persists and a run can resume mid-flight.
+
+**Hard constraint:** the real model endpoint is currently down. Everything here must be
+buildable and **fully testable offline** by substituting a fake `BaseChatModel`. The LLM is
+already abstracted behind `ModelProvider` (`app/config/model_provider.py`) and
+`ModelOptions.custom_model` (`app/init_app.py:43`), which gives us the injection seam.
+
+## Architecture decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| DB engine (default) | **SQLite via `aiosqlite`** | Zero infra, instant tests. Swappable to Postgres through the same SQLAlchemy async API. |
+| DB engine (prod) | **Postgres via `asyncpg`** | Matches `mucgpt-assistant-service` stack; opt-in via config. |
+| DB layer pattern | Mirror `mucgpt-assistant-service/app/database/` (`session.py`, generic `Repository`, declarative `Base`) | Battle-tested in-repo; keeps services consistent. |
+| Checkpointer (default/tests) | `langgraph.checkpoint.memory.MemorySaver` | Built into `langgraph` already; no new dep for tests. |
+| Checkpointer (persistent) | `AsyncSqliteSaver` (dev) / `AsyncPostgresSaver` (prod) | Real cross-request resumption; opt-in. |
+| `thread_id` | The `conversation_id` | One agent thread per conversation — unifies layers A and B. |
+| Offline model | `langchain_core.language_models.fake_chat_models.GenericFakeChatModel` | Scripted, supports streaming + tool calls; no endpoint needed. |
+| Backward compatibility | `conversation_id` is **optional** on `/chat/completions` | Existing stateless frontend keeps working; persistence is additive. |
+
+## Dependency graph / sequencing
+
+```
+01 deps+settings ─┬─> 02 session+repo ─┬─> 03 models ─┬─> 05 conv repo ─> 06 CRUD router ─┐
+                  │                    │              │                                    ├─> 07 persist chat
+                  │                    └─> 04 api models ──────────────────────────────────┘
+                  │
+                  └─> 08 checkpointer provider ─> 09 wire into agent ─> 10 resume/state endpoint
+
+Testing (parallelizable once seams exist):
+  11 fake-model fixture ─> 14 offline e2e + checkpoint test
+  02/03 ──────────────> 12 db unit tests
+  06 ─────────────────> 13 conversations integration tests
+```
+
+## Milestones
+
+- **M1 — Foundations:** issues 01, 02, 03  (DB can be created/queried in tests)
+- **M2 — Chat store (A):** issues 04, 05, 06, 07  (chats persisted + CRUD)
+- **M3 — Agent state (B):** issues 08, 09, 10  (checkpointed, resumable)
+- **M4 — Offline test proof:** issues 11, 12, 13, 14  (whole flow green with model down)
+
+## Definition of done for the epic
+
+- A conversation created via the API survives a process restart (SQLite file / Postgres).
+- `/chat/completions` with a `conversation_id` persists both the user turn and the assistant
+  turn, and the conversation can be reloaded with full history.
+- An interrupted agent run can resume from its checkpoint for the same `conversation_id`.
+- `pytest` passes **with no network / no model endpoint**, exercising the full chat flow via a
+  fake model.
+
+## Issue index
+
+| # | Title | Milestone | Depends on |
+|---|---|---|---|
+| 01 | Add DB deps + DB settings config | M1 | — |
+| 02 | DB session factory + generic Repository | M1 | 01 |
+| 03 | `Conversation` & `Message` models | M1 | 02 |
+| 04 | Conversation/Message API (Pydantic) models | M2 | 01 |
+| 05 | `ConversationRepository` | M2 | 03 |
+| 06 | Conversations CRUD router | M2 | 04, 05 |
+| 07 | Persist turns in `/chat/completions` | M2 | 06 |
+| 08 | Checkpointer provider | M3 | 01 |
+| 09 | Wire checkpointer + `thread_id` into agent | M3 | 08 |
+| 10 | Resume / get-agent-state endpoint | M3 | 09 |
+| 11 | Fake `BaseChatModel` test fixture | M4 | 01 |
+| 12 | DB unit tests (models + repo) | M4 | 02, 03 |
+| 13 | Conversations CRUD integration tests | M4 | 06 |
+| 14 | Offline end-to-end + checkpoint resume test | M4 | 07, 09, 11 |
+
+> Each issue file is self-contained: context, scope, concrete file paths, implementation
+> steps, and acceptance criteria. Keep PRs small — one issue per PR where practical.

--- a/mucgpt-core-service/roadmaps/deletion-tombstones/01-add-deleted-at-column.md
+++ b/mucgpt-core-service/roadmaps/deletion-tombstones/01-add-deleted-at-column.md
@@ -1,0 +1,35 @@
+# 01 — Add `deleted_at` tombstone column to Conversation
+
+**Milestone:** M1 — Backend foundation  ·  **Depends on:** —  ·  **Size:** S  ·  **Action points:** 3
+
+## Context
+`Conversation` (`app/database/models.py`) is hard-deleted today. A tombstone needs
+a durable marker that survives the "delete" so the row can be excluded from reads
+yet still answer "was this deleted?". Schema is built by `Base.metadata.create_all`
+(`app/database/session.py`), which only creates *missing tables* — it will **not**
+add a column to an existing `conversations` table, so existing/Postgres deploys
+need the explicit migration in step 12.
+
+## Scope
+**In:** model column + default. **Out:** soft-delete logic (02), anti-resurrection
+(03), API exposure (04–06), prod migration SQL (12).
+
+## Implementation (3 action points)
+1. `app/database/models.py` — add to `Conversation`:
+   `deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, default=None)`.
+   Place it near `updated_at`; ensure `DateTime` (and `datetime`) are imported the
+   same way `created_at`/`updated_at` already are.
+2. Add a one-line comment that `NULL` = live and a non-null timestamp = tombstoned,
+   and that existing DBs require the step-12 migration (`create_all` won't add it).
+3. Sanity-run `uv run pytest tests/unit/test_conversation_repo.py` to confirm the
+   model still maps and rows insert with `deleted_at IS NULL`.
+
+## Acceptance criteria
+- New conversations persist with `deleted_at = NULL`.
+- Existing repository/router tests stay green.
+- No behavior change yet (column is inert until step 02).
+
+## Notes
+A timestamp (not a bare `deleted` boolean) is deliberate: it records *when* so the
+retention sweep in step 12 can prune old tombstones, and it sorts naturally for a
+`since`-cursor tombstone feed (step 06).

--- a/mucgpt-core-service/roadmaps/deletion-tombstones/02-soft-delete-in-repository.md
+++ b/mucgpt-core-service/roadmaps/deletion-tombstones/02-soft-delete-in-repository.md
@@ -1,0 +1,34 @@
+# 02 — Soft-delete in the repository; reads exclude tombstones
+
+**Milestone:** M1 — Backend foundation  ·  **Depends on:** 01  ·  **Size:** M  ·  **Action points:** 3
+
+## Context
+`ConversationRepository` currently hard-deletes (`session.delete`) and its reads
+(`list_for_user`, `get_for_user`) assume every row is live. Switching to tombstones
+means delete stamps `deleted_at` and every read must filter tombstones out so the
+rest of the system sees a deleted chat as gone.
+
+## Scope
+**In:** `delete()` → soft, `list_for_user`/`get_for_user` exclude tombstoned.
+**Out:** create/resurrection guard + tombstone listing (03), API mapping (04–06).
+
+## Implementation (3 action points)
+1. `delete(conversation_id, user_id)` — instead of `session.delete`, load via
+   `get_for_user`, set `conversation.deleted_at = func.now()`, `flush()`, return
+   `True`; still return `False` when not found/owned. Idempotent: deleting an
+   already-tombstoned chat is a no-op that returns `True` (it stays deleted).
+2. `get_for_user(...)` — add `Conversation.deleted_at.is_(None)` to the `where`, so
+   a tombstoned chat reads as `None` (callers already treat `None` as 404).
+3. `list_for_user(...)` — add the same `deleted_at IS NULL` filter so deleted chats
+   never appear in the normal list. Run `uv run pytest tests/unit/test_conversation_repo.py`.
+
+## Acceptance criteria
+- After `delete()`, the row still exists but `get_for_user`/`list_for_user` omit it.
+- `delete()` is idempotent and ownership is still enforced.
+- `replace_messages`/`append_message` on a tombstoned id fail closed (they go
+  through `get_for_user`, which now returns `None`) — assert this in step 10.
+
+## Notes
+Keep the cascade behavior in mind: hard delete used to cascade to `messages`. Soft
+delete leaves messages attached to the tombstoned row — that's fine (they're hidden
+with the parent) and lets the retention sweep (step 12) remove both together later.

--- a/mucgpt-core-service/roadmaps/deletion-tombstones/03-anti-resurrection-and-tombstone-query.md
+++ b/mucgpt-core-service/roadmaps/deletion-tombstones/03-anti-resurrection-and-tombstone-query.md
@@ -1,0 +1,35 @@
+# 03 — Anti-resurrection on create + tombstone listing query
+
+**Milestone:** M1 — Backend foundation  ·  **Depends on:** 02  ·  **Size:** M  ·  **Action points:** 3
+
+## Context
+The resurrection loop is closed at the source here: a client that still caches a
+deleted chat must not be able to re-create it, and clients need a way to *learn*
+which ids were deleted so they can drop them locally.
+
+## Scope
+**In:** create guard against tombstoned id + a `list_deleted_for_user` repo query.
+**Out:** HTTP mapping of the guard (05) and the feed endpoint (06).
+
+## Implementation (3 action points)
+1. Resurrection guard in `create(...)`: before inserting with a client-supplied id,
+   check whether a row with that `(id, user_id)` exists **including tombstoned**
+   (a dedicated `_get_any(id, user_id)` that omits the `deleted_at IS NULL` filter).
+   If it exists and is tombstoned, raise a typed `ConversationDeletedError`
+   (new, in the repo module) instead of inserting. A live duplicate keeps today's
+   behavior.
+2. Add `async def list_deleted_for_user(self, user_id, since: datetime | None) -> list[Conversation]`:
+   select rows where `deleted_at IS NOT NULL` (and `deleted_at > since` when given),
+   ordered by `deleted_at`. Return enough to emit `{id, deleted_at}` tuples.
+3. Unit-test both: re-creating a tombstoned id raises `ConversationDeletedError`;
+   `list_deleted_for_user` returns only tombstoned ids and respects `since`.
+
+## Acceptance criteria
+- A `create` with a tombstoned id is rejected, not resurrected.
+- A `create` with a brand-new id (or a live duplicate) is unaffected.
+- `list_deleted_for_user` returns tombstoned ids, newest-after-`since` only.
+
+## Notes
+Use the same id for the tombstone and any future re-creation intent: the user truly
+wanting that chat back is a *restore* (out of scope), not a silent re-create. The
+guard intentionally forces that to surface rather than racing the sync.

--- a/mucgpt-core-service/roadmaps/deletion-tombstones/04-api-models.md
+++ b/mucgpt-core-service/roadmaps/deletion-tombstones/04-api-models.md
@@ -1,0 +1,33 @@
+# 04 — Tombstone-aware API models
+
+**Milestone:** M2 — API surface  ·  **Depends on:** 03  ·  **Size:** S  ·  **Action points:** 3
+
+## Context
+`app/api/api_models.py` defines `ConversationSummary`/`ConversationDetail`/
+`CreateConversationRequest`. The tombstone feed needs a response model, and the
+resurrection rejection needs a documented error shape.
+
+## Scope
+**In:** new `DeletedConversation` (feed item) model + 409 conflict body model.
+**Out:** wiring endpoints to them (05, 06), repo logic (02–03).
+
+## Implementation (3 action points)
+1. Add `class DeletedConversation(BaseModel)` with `id: str` and
+   `deleted_at: datetime`. This is the feed item shape (step 06). Keep it minimal —
+   clients only need the id to drop the local chat; `deleted_at` supports a cursor.
+2. Add a small conflict body, e.g. `class ConversationConflict(BaseModel)` with
+   `detail: str` and `conversation_id: str`, used when re-creating a tombstoned id
+   is rejected (step 05). Reuse an existing error model if one already fits.
+3. Do **not** add `deleted_at` to `ConversationSummary`/`ConversationDetail`:
+   tombstoned conversations are never returned by the normal read paths (step 02),
+   so the field would always be null there. Keeping it off avoids implying deleted
+   chats can appear in the main list.
+
+## Acceptance criteria
+- Models import cleanly and serialize the expected JSON (`datetime` → ISO 8601).
+- No change to the existing summary/detail contract.
+
+## Notes
+If #1068 landed first and added a `revision` field on the summary/detail models,
+leave it; tombstones don't touch it. The two features' models are additive and
+independent.

--- a/mucgpt-core-service/roadmaps/deletion-tombstones/05-delete-and-read-endpoints.md
+++ b/mucgpt-core-service/roadmaps/deletion-tombstones/05-delete-and-read-endpoints.md
@@ -1,0 +1,38 @@
+# 05 — Delete endpoint → soft; reads + create honor tombstones
+
+**Milestone:** M2 — API surface  ·  **Depends on:** 03, 04  ·  **Size:** M  ·  **Action points:** 3
+
+## Context
+`conversations_router.py` already calls `repo.delete` / `repo.create` /
+`repo.get_for_user`. Once the repo is tombstone-aware (02–03), the router needs
+only minor wiring: the delete contract stays `204`, reads stay `404`, and the
+resurrection rejection maps to a clear HTTP status.
+
+## Scope
+**In:** map `ConversationDeletedError` from `create` to HTTP; confirm delete/read
+behavior. **Out:** the tombstone feed endpoint (06), frontend (07–09).
+
+## Implementation (3 action points)
+1. `create_conversation`: wrap `repo.create(...)` and catch
+   `ConversationDeletedError` → `raise HTTPException(status_code=409, ...)` with the
+   `ConversationConflict` body. (Use **409 Conflict** rather than 410 Gone: the id
+   is *taken-and-tombstoned*, and 409 reads naturally as "your create lost a race
+   with a delete".) Keep `commit()` only on the success path.
+2. `delete_conversation`: no signature change — `repo.delete` is now soft; still
+   `204` on success, `404` when not found/owned. Confirm the existing test still
+   passes with the new semantics (the row remains, but the endpoint contract is
+   identical).
+3. `get_conversation`: unchanged code, but now `get_for_user` returns `None` for a
+   tombstone → existing `404`. Add a one-line comment that 404 covers both
+   "never existed" and "deleted".
+
+## Acceptance criteria
+- Re-creating a tombstoned id returns **409** with the conflict body and writes
+  nothing.
+- Deleting returns 204 and the chat disappears from list/get (404 thereafter).
+- Existing conversations-router tests stay green.
+
+## Notes
+404-for-tombstone is deliberate: a client asking for a chat the user deleted should
+treat it as gone, not as a distinct "deleted" state. Only the dedicated feed
+(step 06) exposes tombstones, and only as ids to reconcile.

--- a/mucgpt-core-service/roadmaps/deletion-tombstones/06-tombstone-feed-endpoint.md
+++ b/mucgpt-core-service/roadmaps/deletion-tombstones/06-tombstone-feed-endpoint.md
@@ -1,0 +1,36 @@
+# 06 — Tombstone feed endpoint (`GET deleted ids since cursor`)
+
+**Milestone:** M2 — API surface  ·  **Depends on:** 03, 04  ·  **Size:** M  ·  **Action points:** 3
+
+## Context
+Clients need to *learn* which ids were deleted on another device so they can drop
+them locally instead of re-pushing them. This is the read side of the tombstone:
+a list of `{id, deleted_at}`, optionally filtered by a `since` cursor so a client
+only fetches what is new.
+
+## Scope
+**In:** new `GET /conversations/deleted` endpoint backed by `list_deleted_for_user`.
+**Out:** how the frontend consumes it (08), retention/pruning (12).
+
+## Implementation (3 action points)
+1. Add `@router.get("/deleted", response_model=list[DeletedConversation])`
+   `async def list_deleted_conversations(since: datetime | None = None, ...)` that
+   calls `repo.list_deleted_for_user(user_info.user_id, since)` and maps rows to
+   `DeletedConversation`. Register it **before** the `/{conversation_id}` route so
+   `deleted` isn't captured as a conversation id by the path param.
+2. Order results by `deleted_at` ascending and document that a client should
+   remember the max `deleted_at` it has applied and pass it back as `since` next
+   time (incremental sync). With no `since`, return all current tombstones.
+3. Smoke-test via the integration client: delete two chats, `GET /deleted` returns
+   both ids; pass `since=<first deleted_at>` and only the second comes back.
+
+## Acceptance criteria
+- The feed lists exactly the caller's tombstoned ids (ownership enforced).
+- `since` correctly returns only tombstones newer than the cursor.
+- Route ordering doesn't shadow `GET /{conversation_id}`.
+
+## Notes
+Returning ids (not full conversations) keeps the feed cheap and privacy-preserving —
+a deleted chat's content never has to be re-serialized to be reconciled away.
+A `since` cursor on `deleted_at` also means the feed stays small as tombstones are
+pruned (step 12).

--- a/mucgpt-core-service/roadmaps/deletion-tombstones/07-frontend-client-and-types.md
+++ b/mucgpt-core-service/roadmaps/deletion-tombstones/07-frontend-client-and-types.md
@@ -1,0 +1,31 @@
+# 07 — Frontend tombstone-feed client + types
+
+**Milestone:** M3 — Frontend  ·  **Depends on:** 06  ·  **Size:** S  ·  **Action points:** 3
+
+## Context
+`src/api/conversations-client.ts` wraps the conversation endpoints
+(`listConversations`, `getConversation`, `createConversation`,
+`deleteConversation`). It needs a client for the new tombstone feed plus a type
+for the feed item.
+
+## Scope
+**In:** `listDeletedConversations` client fn + `DeletedConversation` TS type +
+MSW mock. **Out:** using it in sync (08), tests (11).
+
+## Implementation (3 action points)
+1. `src/api/models.ts` — add `export interface DeletedConversation { id: string; deleted_at: string; }`
+   mirroring the backend model (ISO-8601 string).
+2. `src/api/conversations-client.ts` — add
+   `export async function listDeletedConversations(since?: string): Promise<DeletedConversation[]>`
+   that GETs `${CONVERSATIONS_BASE}/deleted` with an optional `?since=` query param,
+   using the existing `getConfig()` + `handleApiRequest` pattern.
+3. MSW: add a handler in `src/mocks/` for `GET /conversations/deleted` so mocked dev
+   mode and frontend tests can exercise the deletion-sync path without a backend.
+
+## Acceptance criteria
+- `listDeletedConversations()` returns typed feed items in mocked dev mode.
+- `npm run lint` (prettier + eslint + tsc) clean on touched files.
+
+## Notes
+Keep the `since` param optional and string-typed to match the rest of the client;
+the storage layer (step 08) owns the cursor and decides when to pass it.

--- a/mucgpt-core-service/roadmaps/deletion-tombstones/08-apply-remote-deletions-in-sync.md
+++ b/mucgpt-core-service/roadmaps/deletion-tombstones/08-apply-remote-deletions-in-sync.md
@@ -1,0 +1,38 @@
+# 08 — Apply remote deletions in `runSync`; never resurrect
+
+**Milestone:** M3 — Frontend  ·  **Depends on:** 07  ·  **Size:** M  ·  **Action points:** 3
+
+## Context
+`unifiedHistoryStorage.ts::runSync` is the resurrection engine: it **pushes any
+local chat missing from the backend**. With tombstones available, sync must first
+*apply* remote deletions (drop those local chats) and must *exclude* tombstoned ids
+from the push set, so a deleted chat is removed instead of re-created.
+
+## Scope
+**In:** fetch tombstones → delete locally + filter pushes. **Out:** local-delete
+hardening (09), backend (01–06).
+
+## Implementation (3 action points)
+1. In `runSync`, fetch the tombstone feed alongside the existing
+   `listConversations()` / `chatStorage.getAll()` (extend the `Promise.all`). Build
+   a `deletedIds = new Set(tombstones.map(t => t.id))`.
+2. **Apply deletions:** for every local chat whose id is in `deletedIds`, call
+   `chatStorage.delete(id)` (count failures into the existing `failures` tally so a
+   transient error retries on next refresh). This is how device B learns A deleted X.
+3. **Don't resurrect:** change the push filter from
+   `chat.id && !backendIds.has(chat.id)` to also exclude `deletedIds`
+   (`&& !deletedIds.has(chat.id)`). A chat that is both locally present and
+   tombstoned is deleted (step 2), never pushed. (Defense in depth: even if a push
+   slipped through, the backend now rejects it with 409 from step 05.)
+
+## Acceptance criteria
+- A chat tombstoned on the backend is removed from local IndexedDB on next sync.
+- No tombstoned id is ever pushed/re-created.
+- Live chats still pull/push exactly as before; the `failures`-driven retry still
+  works.
+
+## Notes
+Order matters: apply deletions and compute `deletedIds` **before** the push map so
+the filter sees them. If you later add a `since` cursor (persist the max applied
+`deleted_at` in IndexedDB/localStorage), this same code passes it to
+`listDeletedConversations(since)` to keep the feed incremental.

--- a/mucgpt-core-service/roadmaps/deletion-tombstones/09-local-delete-and-race-hardening.md
+++ b/mucgpt-core-service/roadmaps/deletion-tombstones/09-local-delete-and-race-hardening.md
@@ -1,0 +1,41 @@
+# 09 — Local delete stays deleted (no re-pull race)
+
+**Milestone:** M3 — Frontend  ·  **Depends on:** 08  ·  **Size:** S  ·  **Action points:** 3
+
+## Context
+`deleteEntry` already deletes locally then mirrors to the backend
+(`deleteConversation(id).catch(...)`). With soft-delete the backend keeps a
+tombstone, so the remaining risk is a *local* race: a concurrent `runSync` that
+already fetched the old `backendList` could re-pull the just-deleted chat before
+its tombstone is visible, briefly resurrecting it in IndexedDB.
+
+## Scope
+**In:** make the local delete authoritative against an in-flight sync. **Out:**
+backend semantics (already handled by tombstone + 409).
+
+## Implementation (3 action points)
+1. In `deleteEntry`, await the backend mirror (it's already a tombstone write) and,
+   on success, invalidate the `syncPromise` guard (`this.syncPromise = null`) so the
+   next `getAllHistoryEntries` re-syncs against fresh state including the new
+   tombstone — rather than reusing a resolved promise built from pre-delete data.
+2. Guard the pull path against a deletion that lands mid-sync: in `runSync`'s pull
+   branch, before `chatStorage.create(...)`, re-check the chat isn't in `deletedIds`
+   (recomputed from the tombstone fetch in step 08) — so a chat deleted during the
+   sync window isn't pulled back.
+3. Keep the backend mirror best-effort but **logged**: if `deleteConversation`
+   fails, the local chat is already gone, and the next successful sync's tombstone
+   fetch won't list it (the backend still has it live) — note this gap so step 10/11
+   tests cover "backend mirror failed, chat still deleted locally, reappears on next
+   sync" as the accepted degraded behavior (no data loss, just a reappearance the
+   user can re-delete).
+
+## Acceptance criteria
+- Deleting a chat does not let an in-flight sync resurrect it locally.
+- After a successful backend mirror, the chat stays gone across refreshes/devices.
+- The degraded path (mirror failed) is documented and bounded (reappear-then-redelete,
+  never silent data loss).
+
+## Notes
+This step is deliberately small — most of the durability comes from the backend
+tombstone (02–03) and the apply-deletions sync (08). It only closes the local
+timing window between "deleted here" and "tombstone visible there".

--- a/mucgpt-core-service/roadmaps/deletion-tombstones/10-backend-tests.md
+++ b/mucgpt-core-service/roadmaps/deletion-tombstones/10-backend-tests.md
@@ -1,0 +1,34 @@
+# 10 — Backend tests
+
+**Milestone:** M4 — Tests & docs  ·  **Depends on:** 02, 03, 05, 06  ·  **Size:** M  ·  **Action points:** 3
+
+## Context
+Lock the tombstone contract at the repository and HTTP layers. Mirror the existing
+patterns in `tests/unit/test_conversation_repo.py` and the conversations-router
+integration tests.
+
+## Scope
+**In:** repo soft-delete/no-resurrect/feed unit tests + router 204/409/404 +
+feed-endpoint integration. **Out:** frontend (11).
+
+## Implementation (3 action points)
+1. Repo unit (`tests/unit/test_conversation_repo.py`): `delete()` leaves the row but
+   `get_for_user`/`list_for_user` omit it; `delete()` is idempotent; `create()` with
+   a tombstoned id raises `ConversationDeletedError`; `replace_messages`/
+   `append_message` on a tombstoned id fail closed; `list_deleted_for_user` returns
+   only tombstones and honors `since`.
+2. Router integration: `DELETE` returns 204 and the chat then 404s on `GET`;
+   re-creating the tombstoned id via `POST` returns **409** with the conflict body
+   and writes nothing.
+3. Feed integration: delete two chats, `GET /conversations/deleted` returns both
+   ids (ownership-scoped — another user's tombstones don't leak); `since=<cursor>`
+   returns only the newer one. Run `uv run pytest` + `uv run ruff check`.
+
+## Acceptance criteria
+- All new tests pass; full suite stays green; `ruff` clean.
+- Cross-user isolation is asserted on both the feed and the resurrection guard.
+
+## Notes
+Assert the resurrection guard writes nothing on 409 (no partial row) — it's the
+core anti-resurrection guarantee and the analogue of #1068's "no model call on
+conflict" check.

--- a/mucgpt-core-service/roadmaps/deletion-tombstones/11-frontend-tests.md
+++ b/mucgpt-core-service/roadmaps/deletion-tombstones/11-frontend-tests.md
@@ -1,0 +1,32 @@
+# 11 — Frontend tests
+
+**Milestone:** M4 — Tests & docs  ·  **Depends on:** 08, 09  ·  **Size:** M  ·  **Action points:** 3
+
+## Context
+Cover the deletion-sync flow and prove the resurrection loop is gone. Match the
+existing Vitest setup and mock the conversation + tombstone-feed APIs (step 07).
+
+## Scope
+**In:** unit tests for apply-deletions, no-resurrect push filter, and local-delete
+race. **Out:** backend (10).
+
+## Implementation (3 action points)
+1. Apply-deletions: seed IndexedDB with a chat, mock the tombstone feed to return
+   that id, run `runSync`, assert the chat is removed from `chatStorage` and the
+   list no longer shows it.
+2. No-resurrection: seed a local chat that is **not** in `backendList` but **is** in
+   the tombstone feed; assert `runSync` does **not** call `createConversation` for
+   it (the regression test for the original bug).
+3. Local delete: `deleteEntry` removes the chat locally, mirrors to the backend, and
+   the next `getAllHistoryEntries` (fresh sync) does not bring it back; cover the
+   degraded path (mocked backend mirror failure) per step 09's accepted behavior.
+
+## Acceptance criteria
+- New tests pass; `npm run lint` (prettier + eslint + tsc) clean on touched files.
+- The "deleted chat reappears after sync" scenario fails *without* the step-08 fix
+  and passes with it (true regression coverage).
+
+## Notes
+Write test 2 so it would have caught the original resurrection: a chat absent from
+the backend list is normally pushed — the assertion is that the tombstone overrides
+that and suppresses the push.

--- a/mucgpt-core-service/roadmaps/deletion-tombstones/12-docs-migration-and-retention.md
+++ b/mucgpt-core-service/roadmaps/deletion-tombstones/12-docs-migration-and-retention.md
@@ -1,0 +1,39 @@
+# 12 — Docs + production migration + tombstone retention
+
+**Milestone:** M4 — Tests & docs  ·  **Depends on:** 01, 06  ·  **Size:** S  ·  **Action points:** 3
+
+## Context
+`create_all` adds the `deleted_at` column only on **fresh** DBs, so existing
+Postgres deployments need an explicit migration. The new delete semantics, the
+feed endpoint, and the long-term growth of tombstone rows all need documenting.
+
+## Scope
+**In:** migration SQL/Alembic note, API + behavior docs, retention strategy.
+**Out:** code (01–09).
+
+## Implementation (3 action points)
+1. Migration: provide the column add for existing DBs —
+   `ALTER TABLE conversations ADD COLUMN deleted_at TIMESTAMPTZ NULL;`
+   If/when core-service adopts Alembic (it currently has none; only
+   `mucgpt-assistant-service-migrations/` exists), add this as a revision; otherwise
+   document the manual ALTER in the deploy runbook.
+2. Docs: in `CHAT_PERSISTENCE.md` / core-service README, document that delete is now
+   a **soft delete** (row retained with `deleted_at`), that reads exclude tombstones
+   (404), that re-creating a tombstoned id returns 409, and the
+   `GET /conversations/deleted?since=` feed + how clients reconcile with it.
+3. Retention: document (and optionally implement) a pruning sweep — hard-delete
+   conversations whose `deleted_at` is older than a retention window (e.g. 30–90
+   days), since by then all clients have reconciled. Note the trade-off: a client
+   offline longer than the window won't see the tombstone and could resurrect
+   (bounded, acceptable; backend 409 still blocks the push if the row survives, so
+   prune the row only after the window). Cross-link issue #1068.
+
+## Acceptance criteria
+- A deployer can add the column to an existing Postgres DB from the docs alone.
+- Soft-delete semantics, 409-on-resurrect, and the feed are documented in one place.
+- A retention/pruning policy (even if "manual for now") is written down.
+
+## Notes
+Retention closes the loop opened by soft delete: tombstones accumulate forever
+otherwise. Pruning after a generous window keeps the feed and table bounded while
+preserving the anti-resurrection guarantee for any realistically-online client.

--- a/mucgpt-core-service/roadmaps/deletion-tombstones/README.md
+++ b/mucgpt-core-service/roadmaps/deletion-tombstones/README.md
@@ -1,0 +1,79 @@
+# Deletion tombstones to stop resurrecting cross-device chats
+
+Tracks GitHub issue **it-at-m/mucgpt#1069** (follow-up from PR #1067).
+
+## Problem
+Server-side delete is a **hard delete** (`ConversationRepository.delete` →
+`session.delete(conversation)`), and the frontend reconcile (`runSync`) **pushes
+any local chat that is missing from the backend** as a "migration" of a
+pre-existing local chat. The two combine into a resurrection loop:
+
+1. Device A deletes chat *X* → row hard-deleted on the backend, removed from A.
+2. Device B still has *X* in IndexedDB. Its next `runSync` sees *X* is not in
+   `backendIds` and **re-creates it** on the backend (`createConversation`).
+3. Device A's next sync pulls *X* back. The chat the user deleted reappears
+   everywhere — **deletes never stick across devices.**
+
+There is also no way for B to *learn* that A deleted *X*; B only ever pulls or
+pushes, it never removes.
+
+## Chosen approach — soft-delete tombstones
+Replace the hard delete with a server-owned **tombstone** so a deletion is a
+durable, queryable fact instead of an absence:
+
+- Add nullable `deleted_at` to `Conversation`. `delete()` sets it (soft delete)
+  instead of removing the row.
+- `list_for_user` / `get_for_user` **exclude** tombstoned conversations, so
+  normal reads behave exactly as today (a deleted chat 404s / is absent).
+- `create` with a **tombstoned id does not resurrect** — the server rejects it
+  (HTTP 409/410), killing the push-back path at the source.
+- A **tombstone feed** lets clients *learn* about deletions: a list of deleted
+  ids (optionally `since` a cursor) the client applies locally by removing those
+  chats from IndexedDB instead of re-pushing them.
+
+Net effect: a delete on any device propagates; no client can resurrect a chat it
+merely still has cached.
+
+## Backward compatibility / rollout
+- The tombstone column is additive and inert until `delete()` is switched to soft
+  (step 02); old rows simply have `deleted_at = NULL`.
+- The tombstone feed is a **new** endpoint; old clients ignore it and keep
+  working (they just won't auto-remove remotely-deleted chats — no regression
+  versus today, where the same chats currently *resurrect*). Backend can ship
+  first; frontend second. No flag day.
+
+## Interaction with #1068 (optimistic concurrency)
+Independent but complementary. #1068 guards *content overwrites* via a `revision`
+precondition; #1069 guards *existence* via tombstones. They touch the same
+`Conversation` model and the same `runSync`, so whichever lands first, the second
+rebases its model/migration step on top. Tombstoned conversations are exempt from
+revision checks (a delete is terminal).
+
+## Milestones & steps (each step ≈ 3 action points)
+
+**M1 — Backend foundation**
+- `01-add-deleted-at-column.md` — `deleted_at` tombstone column + schema note
+- `02-soft-delete-in-repository.md` — `delete()` sets tombstone; reads exclude it
+- `03-anti-resurrection-and-tombstone-query.md` — block re-create + list-deleted query
+
+**M2 — API surface**
+- `04-api-models.md` — tombstone-aware response/error models
+- `05-delete-and-read-endpoints.md` — soft-delete endpoint + 410/404 on reads
+- `06-tombstone-feed-endpoint.md` — `GET deleted ids (since cursor)` for sync
+
+**M3 — Frontend**
+- `07-frontend-client-and-types.md` — tombstone-feed client + TS types
+- `08-apply-remote-deletions-in-sync.md` — drop tombstoned chats; never push them
+- `09-local-delete-and-race-hardening.md` — local delete stays deleted (no re-pull)
+
+**M4 — Tests & docs**
+- `10-backend-tests.md` — soft-delete, no-resurrect, tombstone-feed tests
+- `11-frontend-tests.md` — deletion-sync / anti-resurrection tests
+- `12-docs-migration-and-retention.md` — column migration + tombstone pruning/retention
+
+## Notes
+- These planning files live under `issues/` which is git-ignored (local scratch),
+  matching the `chat-persistence/` and `optimistic-concurrency/` sets.
+- `deleted_at` (timestamp, not a bare boolean) doubles as the input to a retention
+  sweep (step 12): tombstones can be hard-pruned after N days once all clients have
+  reconciled.

--- a/mucgpt-core-service/roadmaps/optimistic-concurrency/01-add-revision-column.md
+++ b/mucgpt-core-service/roadmaps/optimistic-concurrency/01-add-revision-column.md
@@ -1,0 +1,34 @@
+# 01 — Add `revision` column to Conversation
+
+**Milestone:** M1 — Backend foundation  ·  **Depends on:** —  ·  **Size:** S  ·  **Action points:** 3
+
+## Context
+`Conversation` (`app/database/models.py`) has no version field. Optimistic
+concurrency needs a server-owned monotonic integer to compare against the
+client's expectation. The core service builds schema via
+`Base.metadata.create_all` (`app/database/session.py`), which only creates
+*missing tables* — it will **not** add a column to an existing `conversations`
+table, so existing/Postgres deployments need an explicit migration (see step 12).
+
+## Scope
+**In:** model column + default. **Out:** incrementing it (02), conflict logic (03),
+API exposure (04), prod migration SQL (12).
+
+## Implementation (3 action points)
+1. `app/database/models.py` — add to `Conversation`:
+   `revision: Mapped[int] = mapped_column(Integer, server_default="0", default=0, nullable=False)`.
+   Place it near `updated_at`; reuse the already-imported `Integer`.
+2. Confirm fresh DBs get the column automatically: new SQLite/test DBs are built
+   by `create_all`, so no test fixture change is needed. Add a one-line code
+   comment that existing DBs require the step-12 migration.
+3. Sanity-run the unit DB tests (`uv run pytest tests/unit/test_conversation_repo.py`)
+   to confirm the model still maps and rows insert with `revision == 0`.
+
+## Acceptance criteria
+- New conversations persist with `revision = 0`.
+- Existing repository/router tests stay green.
+- No behavior change yet (column is inert until step 02).
+
+## Notes
+Integer (not `updated_at`) is the precondition key: exact equality is unambiguous
+and immune to clock/timestamp-precision issues.

--- a/mucgpt-core-service/roadmaps/optimistic-concurrency/02-bump-revision-on-mutations.md
+++ b/mucgpt-core-service/roadmaps/optimistic-concurrency/02-bump-revision-on-mutations.md
@@ -1,0 +1,37 @@
+# 02 — Bump `revision` on every message mutation
+
+**Milestone:** M1 — Backend foundation  ·  **Depends on:** 01  ·  **Size:** S  ·  **Action points:** 3
+
+## Context
+The `revision` is only meaningful if the server advances it whenever stored
+history changes. The two mutation paths in `ConversationRepository`
+(`app/database/conversation_repo.py`) are `replace_messages` and
+`append_message`; `create` initializes a conversation.
+
+## Scope
+**In:** increment `revision` on content mutations. **Out:** the precondition/
+conflict check (03), metadata-only updates (title/favorite should NOT bump).
+
+## Implementation (3 action points)
+1. `replace_messages` — after re-inserting messages, set
+   `conversation.revision = conversation.revision + 1` alongside the existing
+   `updated_at` touch (do it in the same flush so it is atomic with the write).
+2. `append_message` — after the successful SAVEPOINT insert, likewise bump
+   `conversation.revision`. Keep it inside the same transaction as the append so
+   revision and message stay consistent under the retry loop.
+3. Return the new revision: have both methods return the post-bump
+   `conversation.revision` (e.g. include it on the returned object, already
+   refreshed) so callers (step 05/06) can surface it without a re-query.
+
+## Acceptance criteria
+- Each successful `replace_messages` / `append_message` increments `revision` by
+  exactly 1.
+- `update_meta` (title/favorite) does **not** change `revision`.
+- A turn that both replaces history and appends an assistant message advances
+  `revision` deterministically (document whether that is +1 or +2 — see Notes).
+
+## Notes
+A normal turn calls `replace_messages` (sync client history) **then**
+`append_message` (assistant turn) → `revision` advances twice. That is fine: the
+client just needs the *final* value returned by the request (step 05/06). Decide
+and document this so step 08's client expectation matches.

--- a/mucgpt-core-service/roadmaps/optimistic-concurrency/03-conflict-check-in-repository.md
+++ b/mucgpt-core-service/roadmaps/optimistic-concurrency/03-conflict-check-in-repository.md
@@ -1,0 +1,36 @@
+# 03 — Optimistic-concurrency precondition in the repository
+
+**Milestone:** M1 — Backend foundation  ·  **Depends on:** 02  ·  **Size:** M  ·  **Action points:** 3
+
+## Context
+The actual guard: when a client supplies the revision its history is based on,
+`replace_messages` must refuse to overwrite if the stored revision has moved on.
+This is the step that prevents last-write-wins data loss.
+
+## Scope
+**In:** optional `expected_revision` param + mismatch → raise a typed error.
+**Out:** HTTP mapping (05), streaming (06), client behavior (09).
+
+## Implementation (3 action points)
+1. Define a `ConflictError(Exception)` (e.g. in `database/conversation_repo.py`
+   or a small `database/errors.py`) carrying `current_revision` and
+   `expected_revision`.
+2. `replace_messages(..., expected_revision: int | None = None)` — after loading
+   the owned conversation and **before** clearing/re-inserting: if
+   `expected_revision is not None and conversation.revision != expected_revision`,
+   raise `ConflictError(current=conversation.revision, expected=expected_revision)`.
+   When `expected_revision is None`, behave exactly as today (backward-compatible).
+3. Ensure the check reads a fresh value: rely on the row already loaded in this
+   transaction; document that the DB isolation level (READ COMMITTED on Postgres)
+   plus the single-statement write make a stale read-then-overwrite window
+   negligible, and that the unique-sequence retry (PR #1067) covers the residual.
+
+## Acceptance criteria
+- Mismatched `expected_revision` raises `ConflictError` and writes nothing.
+- Matching or absent `expected_revision` applies the write (and bumps revision).
+- Cross-user ownership behavior is unchanged (still returns `None`).
+
+## Notes
+Keep `ConflictError` distinct from `IntegrityError`: the latter is the
+sequence-collision retry (intra-conversation), the former is the cross-client
+precondition failure (inter-client). They surface differently (retry vs 409).

--- a/mucgpt-core-service/roadmaps/optimistic-concurrency/04-api-models.md
+++ b/mucgpt-core-service/roadmaps/optimistic-concurrency/04-api-models.md
@@ -1,0 +1,34 @@
+# 04 — API models: request/response/detail revision fields
+
+**Milestone:** M2 — API surface  ·  **Depends on:** 03  ·  **Size:** S  ·  **Action points:** 3
+
+## Context
+The client needs to send the revision it is based on and read back the new one.
+Touch `app/api/api_models.py` (`ChatCompletionRequest` at L70, conversation
+models around L482) and the response shapes.
+
+## Scope
+**In:** Pydantic field additions + a documented 409 body. **Out:** router logic
+(05/06), frontend TS mirror (07).
+
+## Implementation (3 action points)
+1. `ChatCompletionRequest` — add
+   `conversation_revision: int | None = Field(None, description="Revision the client's history is based on; enables optimistic-concurrency rejection (409) on stale overwrite.")`
+   next to `conversation_id`.
+2. Expose the current revision on reads/writes: add `revision: int` to
+   `ConversationSummary` / `ConversationDetail` (list + get) and to the create
+   response, so a freshly pulled or created chat carries its revision.
+3. Define the conflict payload: a small `ConversationConflict` model
+   (`detail`, `current_revision`, `expected_revision`) and document it as the 409
+   response in the `/chat/completions` route `responses={409: ...}`.
+
+## Acceptance criteria
+- OpenAPI shows `conversation_revision` on the request and `revision` on
+  conversation read/create models.
+- 409 response schema is documented on the chat-completions route.
+- Existing clients that omit the field still validate.
+
+## Notes
+Decide how the *non-streaming* response returns the new revision: simplest is to
+add `conversation_revision: int | None` to `ChatCompletionResponse` (populated
+only when a conversation_id was involved). Streaming uses step 06 instead.

--- a/mucgpt-core-service/roadmaps/optimistic-concurrency/05-chat-router-nonstreaming.md
+++ b/mucgpt-core-service/roadmaps/optimistic-concurrency/05-chat-router-nonstreaming.md
@@ -1,0 +1,36 @@
+# 05 — Wire precondition + 409 in chat_router (non-streaming)
+
+**Milestone:** M2 — API surface  ·  **Depends on:** 03, 04  ·  **Size:** M  ·  **Action points:** 3
+
+## Context
+`app/api/routers/chat_router.py` calls `repo.replace_messages(...)` each turn
+(around L132) then appends the assistant turn. It must pass the client's
+expected revision, translate `ConflictError` to HTTP 409, and return the final
+revision on the non-streaming path.
+
+## Scope
+**In:** non-streaming flow + 409 mapping. **Out:** SSE revision (06).
+
+## Implementation (3 action points)
+1. Pass the precondition: call
+   `repo.replace_messages(conversation_id, user_id, msgs, expected_revision=request.conversation_revision)`.
+   Wrap it so a raised `ConflictError` becomes
+   `raise HTTPException(status_code=409, detail=ConversationConflict(...))` —
+   and crucially do this **before** invoking the model (don't spend a generation
+   on a turn that will be rejected).
+2. Capture the post-turn revision: after the successful `append_message`, read
+   the returned revision (step 02) and set it on the `ChatCompletionResponse`
+   (`conversation_revision`).
+3. Keep ordering correct: conflict check + history sync happen, `await session.commit()`
+   as today; ensure the 409 path does not commit a partial write (it raised
+   before any mutation, so nothing to roll back — verify with a test in step 10).
+
+## Acceptance criteria
+- Stale `conversation_revision` → 409 with the conflict body, no model call, no DB
+  write.
+- Successful non-streaming turn returns the new `conversation_revision`.
+- Requests without `conversation_revision` behave exactly as before.
+
+## Notes
+Reject **before** generation is the cost-saver and the correctness win: it avoids
+persisting a turn the client must discard anyway.

--- a/mucgpt-core-service/roadmaps/optimistic-concurrency/06-streaming-revision-event.md
+++ b/mucgpt-core-service/roadmaps/optimistic-concurrency/06-streaming-revision-event.md
@@ -1,0 +1,34 @@
+# 06 — Surface revision on the streaming path
+
+**Milestone:** M2 — API surface  ·  **Depends on:** 05  ·  **Size:** M  ·  **Action points:** 3
+
+## Context
+For streaming, HTTP headers are flushed before the assistant turn is appended, so
+the *new* revision isn't known at header time. The conflict check, however, runs
+**before** the stream starts (step 05 logic), so a stale turn is still rejected
+with 409 up front. Only the post-turn revision needs a stream-time channel.
+
+## Scope
+**In:** pre-stream 409 + a final SSE event carrying the new revision. **Out:**
+client parsing (08).
+
+## Implementation (3 action points)
+1. Pre-stream guard: run the same `replace_messages(..., expected_revision=...)`
+   conflict check before returning the `StreamingResponse`, so a 409 is raised as
+   a normal HTTP error (no stream opened) — identical to step 05.
+2. Emit the revision at end-of-stream: in `sse_generator`'s `finally`, after the
+   successful `append_message`, yield a final event such as
+   `data: {"object": "conversation.revision", "conversation_revision": <int>}\n\n`
+   before/with the existing `[DONE]`. Only emit when `not stream_failed`.
+3. Document the event contract in the route docstring so the frontend (step 08)
+   knows the exact shape and ordering relative to `[DONE]`.
+
+## Acceptance criteria
+- Stale revision on a streaming request → 409 before any chunk is sent.
+- A successful stream ends with a revision event reflecting the post-turn value.
+- Failed/aborted streams emit no revision event (consistent with PR #1067's
+  no-persist-on-error rule).
+
+## Notes
+Reuse the existing `stream_failed` flag from PR #1067 so the revision event and
+persistence stay gated by the same success condition.

--- a/mucgpt-core-service/roadmaps/optimistic-concurrency/07-frontend-models-and-storage.md
+++ b/mucgpt-core-service/roadmaps/optimistic-concurrency/07-frontend-models-and-storage.md
@@ -1,0 +1,33 @@
+# 07 — Frontend models + local revision storage
+
+**Milestone:** M3 — Frontend  ·  **Depends on:** 04  ·  **Size:** M  ·  **Action points:** 3
+
+## Context
+The client must remember the revision each chat is based on. Touch
+`mucgpt-frontend/src/api/models.ts` (mirror the new fields) and the chat storage
+layer (IndexedDB) that holds local chats.
+
+## Scope
+**In:** TS types + persisted revision field. **Out:** sending/receiving it (08),
+409 handling (09).
+
+## Implementation (3 action points)
+1. `models.ts` — add `conversation_revision?: number` to the chat request type and
+   `revision?: number` to `ConversationSummary` / `ConversationDetail` (mirror
+   step 04). Keep optional for backward compatibility.
+2. Storage schema — add a `revision?: number` field to the stored chat record
+   (the IndexedDB chat object) and persist it when creating/updating a chat.
+   Bump the IndexedDB schema version only if the store requires it for the new
+   field; otherwise treat it as an optional property on existing records.
+3. Sync hydration — in `UnifiedHistory/unifiedHistoryStorage.ts` `runSync` pulls,
+   store `detail.revision` on the local record so a pulled chat starts with the
+   server's current revision.
+
+## Acceptance criteria
+- Local chat records can hold a `revision`.
+- Pulled/synced chats persist the server revision locally.
+- No change for chats that have no revision yet (treated as "unknown").
+
+## Notes
+"Unknown/absent revision" must mean *don't send a precondition* (so the first
+turn of a brand-new chat is never a false conflict) — see step 08.

--- a/mucgpt-core-service/roadmaps/optimistic-concurrency/08-send-and-capture-revision.md
+++ b/mucgpt-core-service/roadmaps/optimistic-concurrency/08-send-and-capture-revision.md
@@ -1,0 +1,33 @@
+# 08 — Send + capture revision in makeApiRequest
+
+**Milestone:** M3 — Frontend  ·  **Depends on:** 05, 06, 07  ·  **Size:** M  ·  **Action points:** 3
+
+## Context
+`mucgpt-frontend/src/pages/page_helpers.ts` `makeApiRequest` builds the chat
+request and processes the SSE stream. It must send the local revision and capture
+the new one returned by the server.
+
+## Scope
+**In:** request field + reading the returned revision (stream + non-stream).
+**Out:** what to do on 409 (09).
+
+## Implementation (3 action points)
+1. Send it: include `conversation_revision: <local revision for conversation_id>`
+   in the `ChatRequest` (omit when unknown, e.g. a brand-new chat — see step 07).
+2. Capture it (streaming): in the SSE loop, recognize the
+   `object === "conversation.revision"` event from step 06 and remember the value;
+   for the non-streaming path, read `conversation_revision` off the response body.
+3. Persist it: when saving the turn (`storageService.appendMessage` / `create`),
+   write the captured revision onto the local chat record so the next turn sends
+   the up-to-date precondition.
+
+## Acceptance criteria
+- Each turn for a persisted chat sends the last known revision.
+- The new revision from the server is stored locally after a successful turn.
+- Brand-new chats (no revision yet) send no precondition and are never falsely
+  rejected.
+
+## Notes
+Because a normal turn advances revision twice server-side (replace + append, see
+step 02), always trust the *server-returned* final value rather than incrementing
+locally.

--- a/mucgpt-core-service/roadmaps/optimistic-concurrency/09-conflict-handling.md
+++ b/mucgpt-core-service/roadmaps/optimistic-concurrency/09-conflict-handling.md
@@ -1,0 +1,35 @@
+# 09 — Frontend 409 conflict handling (pull-and-reconcile)
+
+**Milestone:** M3 — Frontend  ·  **Depends on:** 08  ·  **Size:** M  ·  **Action points:** 3
+
+## Context
+This realizes the chosen policy: on a 409 the client does not overwrite; it pulls
+the authoritative server history, reconciles its local copy, and tells the user.
+
+## Scope
+**In:** detect 409 → reload chat + non-blocking notice + re-enable resend.
+**Out:** automatic merge of divergent turns (explicitly deferred — see Notes).
+
+## Implementation (3 action points)
+1. Detect: in `makeApiRequest` (and/or the chat API wrapper), treat HTTP 409 from
+   `/chat/completions` distinctly from generic errors; parse the conflict body
+   (`current_revision`).
+2. Reconcile: fetch the latest conversation (`getConversation(id)`), replace the
+   local chat's messages + `revision` with the server copy, and dispatch the UI
+   update so the user sees the authoritative history (their un-sent prompt is
+   preserved in the input box, not lost).
+3. Notify: show a non-blocking notice ("This chat was updated on another device —
+   reloaded the latest version; please resend your message.") and clear the
+   loading state. Do not auto-resend (avoid duplicate turns).
+
+## Acceptance criteria
+- A 409 reloads the chat to the server state and does not lose the user's pending
+  input.
+- The user is informed and can resend; resend now carries the refreshed revision
+  and succeeds.
+- No duplicate turns are created by the conflict flow.
+
+## Notes
+Auto-merging the two divergent branches is a separate UX feature; rejecting +
+reloading is the safe minimum that eliminates data loss. Revisit only if users
+hit conflicts frequently.

--- a/mucgpt-core-service/roadmaps/optimistic-concurrency/10-backend-tests.md
+++ b/mucgpt-core-service/roadmaps/optimistic-concurrency/10-backend-tests.md
@@ -1,0 +1,33 @@
+# 10 — Backend tests
+
+**Milestone:** M4 — Tests & docs  ·  **Depends on:** 03, 05, 06  ·  **Size:** M  ·  **Action points:** 3
+
+## Context
+Lock in the guard at the repository and HTTP layers. Mirror the existing patterns
+in `tests/unit/test_conversation_repo.py` and `tests/integration/test_chat_router.py`.
+
+## Scope
+**In:** repo conflict unit test, router 409 integration test, revision-increment
+assertions. **Out:** frontend (11).
+
+## Implementation (3 action points)
+1. Repo unit (`tests/unit/test_conversation_repo.py`): `replace_messages` with a
+   stale `expected_revision` raises `ConflictError` and leaves stored messages +
+   revision unchanged; with a matching one it applies and bumps revision. Add an
+   increment assertion to the existing append test.
+2. Router integration (`tests/integration/test_chat_router.py`): a turn with a
+   stale `conversation_revision` returns **409** with the conflict body, makes
+   **no** model call (assert via the fake model), and persists nothing; a matching
+   turn returns the new `conversation_revision`.
+3. Streaming integration: a stale revision on a streaming request yields 409 before
+   any SSE chunk; a successful stream ends with the `conversation.revision` event.
+   Keep using the fake-model fixture from PR #1067.
+
+## Acceptance criteria
+- All new tests pass; full suite stays green; `ruff` clean.
+- Backward-compat test: omitting `conversation_revision` reproduces today's
+  behavior (no 409).
+
+## Notes
+Assert "no model call on conflict" explicitly — it is both a cost guarantee and
+proof the reject-before-generate ordering (step 05) holds.

--- a/mucgpt-core-service/roadmaps/optimistic-concurrency/11-frontend-tests.md
+++ b/mucgpt-core-service/roadmaps/optimistic-concurrency/11-frontend-tests.md
@@ -1,0 +1,29 @@
+# 11 — Frontend tests
+
+**Milestone:** M4 — Tests & docs  ·  **Depends on:** 08, 09  ·  **Size:** M  ·  **Action points:** 3
+
+## Context
+Cover the client revision plumbing and the 409 reconcile flow. Match the existing
+frontend test setup (Vitest) and mock the chat/conversation API.
+
+## Scope
+**In:** unit tests for send/capture + conflict reconcile. **Out:** backend (10).
+
+## Implementation (3 action points)
+1. Send/capture: assert `makeApiRequest` includes `conversation_revision` when the
+   local chat has one and omits it for a brand-new chat; assert the
+   `conversation.revision` SSE event (and non-streaming body) updates the stored
+   record.
+2. Conflict reconcile: mock a 409 from `/chat/completions`; assert the client
+   calls `getConversation`, replaces local messages + revision with the server
+   copy, preserves the pending input, and surfaces the notice without auto-resend.
+3. Regression: a successful resend after a 409 sends the refreshed revision and
+   persists the new one; no duplicate local turns are created.
+
+## Acceptance criteria
+- New tests pass; `npm run lint` (prettier + eslint + tsc) clean on touched files.
+- No console errors in the conflict path.
+
+## Notes
+If frontend coverage for `makeApiRequest` is thin today, scope the test to the
+extracted revision/conflict helpers rather than the whole streaming function.

--- a/mucgpt-core-service/roadmaps/optimistic-concurrency/12-docs-and-migration.md
+++ b/mucgpt-core-service/roadmaps/optimistic-concurrency/12-docs-and-migration.md
@@ -1,0 +1,33 @@
+# 12 — Docs + production column migration
+
+**Milestone:** M4 — Tests & docs  ·  **Depends on:** 01, 04  ·  **Size:** S  ·  **Action points:** 3
+
+## Context
+`create_all` adds the `revision` column only on **fresh** DBs. Existing Postgres
+deployments need an explicit migration, and the new request/response contract +
+conflict behavior should be documented.
+
+## Scope
+**In:** migration SQL/Alembic note, API docs, rollout notes. **Out:** code (01–09).
+
+## Implementation (3 action points)
+1. Migration: provide the column add for existing DBs —
+   `ALTER TABLE conversations ADD COLUMN revision INTEGER NOT NULL DEFAULT 0;`
+   If/when core-service adopts Alembic (it currently has none; only
+   `mucgpt-assistant-service-migrations/` exists), add this as the first revision;
+   otherwise document the manual ALTER in the deploy runbook.
+2. API docs: document `conversation_revision` (request), the `revision` fields on
+   conversation read/create, the `409` conflict body, and the streaming
+   `conversation.revision` event in the core-service README / OpenAPI notes.
+3. Rollout: note the opt-in/back-compat contract (omitting `conversation_revision`
+   = today's behavior), so backend can ship before the frontend without breaking
+   old clients; record the cross-link to issue #1069 (tombstones) as related.
+
+## Acceptance criteria
+- A deployer can apply the column to an existing Postgres DB from the docs alone.
+- The API contract and conflict semantics are documented in one discoverable place.
+- Rollout ordering (backend-first, frontend-second) is written down.
+
+## Notes
+Backend-first is safe precisely because the guard is opt-in: no client sends
+`conversation_revision` until step 08 ships, so 409s can't occur prematurely.

--- a/mucgpt-core-service/roadmaps/optimistic-concurrency/README.md
+++ b/mucgpt-core-service/roadmaps/optimistic-concurrency/README.md
@@ -1,0 +1,61 @@
+# Optimistic concurrency guard for cross-device chat turns
+
+Tracks GitHub issue **it-at-m/mucgpt#1068** (follow-up from PR #1067).
+
+## Problem
+Every chat turn rewrites the stored conversation to the client's snapshot
+(`ConversationRepository.replace_messages`) before appending the assistant turn.
+If the same chat is open in two tabs/devices, the later request can erase turns
+already persisted by the other client but not yet present in its local history —
+silent **last-write-wins data loss**.
+
+(The single-conversation append-sequence race was already fixed in PR #1067 via a
+SAVEPOINT + retry on `uq_message_sequence`. This is the higher-level cross-client
+overwrite.)
+
+## Chosen approach — reject-and-reload (lightweight)
+Add a server-authoritative integer `revision` per conversation:
+
+- The client sends the `revision` its current history is based on
+  (`conversation_revision` on the chat request).
+- On a write, the server compares stored `revision` vs the client's expectation:
+  - **match** → apply, bump `revision`, return the new value.
+  - **mismatch** → reject with **HTTP 409** and do **not** overwrite.
+- The client handles 409 by pulling the latest server history and reconciling
+  (reload the chat, surface a non-blocking notice), then the user can resend.
+
+Merge-on-conflict is explicitly **out of scope** (see Notes); rejecting kills the
+data-loss path without committing to merge UX.
+
+## Backward compatibility / rollout
+`conversation_revision` is **optional**. When a request omits it, the server skips
+the precondition check and behaves exactly as today — so the guard is opt-in per
+request and old clients keep working. No flag day.
+
+## Milestones & steps (each step ≈ 3 action points)
+
+**M1 — Backend foundation**
+- `01-add-revision-column.md` — `revision` column + schema/backfill strategy
+- `02-bump-revision-on-mutations.md` — increment on every message mutation
+- `03-conflict-check-in-repository.md` — precondition check + `ConflictError`
+
+**M2 — API surface**
+- `04-api-models.md` — request/response/detail revision fields + 409 schema
+- `05-chat-router-nonstreaming.md` — wire precondition + map to HTTP 409
+- `06-streaming-revision-event.md` — emit new revision on the SSE path
+
+**M3 — Frontend**
+- `07-frontend-models-and-storage.md` — TS types + persist revision locally
+- `08-send-and-capture-revision.md` — plumb revision through `makeApiRequest`
+- `09-conflict-handling.md` — 409 → pull-and-reconcile + user notice
+
+**M4 — Tests & docs**
+- `10-backend-tests.md` — repo conflict + router 409 + increment tests
+- `11-frontend-tests.md` — revision plumbing + 409 reconcile tests
+- `12-docs-and-migration.md` — README/config + prod column migration note
+
+## Notes
+- These planning files live under `issues/` which is git-ignored (local scratch),
+  matching the `chat-persistence/` set.
+- Revision is a monotonic integer owned by the server; never trust a client-set
+  value except as the *expected* precondition.

--- a/mucgpt-core-service/tests/integration/test_chat_persistence_e2e.py
+++ b/mucgpt-core-service/tests/integration/test_chat_persistence_e2e.py
@@ -128,6 +128,33 @@ def test_unknown_conversation_id_is_auto_created(test_client_with_fake_model: Te
     assert len(roles) == 2
 
 
+def test_chat_to_deleted_conversation_id_is_rejected_not_resurrected(
+    test_client_with_fake_model: TestClient,
+) -> None:
+    """The chat auto-create path is the *second* resurrection vector: a send to
+    a tombstoned conversation_id must not bring the chat back. The guard fires
+    before the model is invoked, so it returns 409 (not a 500) and writes
+    nothing."""
+    client = test_client_with_fake_model
+    conv_id = _create_conversation(client, title="to-delete")
+    assert client.delete(f"{BASE}/{conv_id}").status_code == 204
+
+    resp = client.post(
+        CHAT,
+        json={
+            "model": "fake",
+            "messages": [{"role": "user", "content": "are you back?"}],
+            "stream": False,
+            "conversation_id": conv_id,
+        },
+    )
+    assert resp.status_code == 409, resp.text
+
+    # Nothing resurrected: the chat is still gone and still tombstoned.
+    assert client.get(f"{BASE}/{conv_id}").status_code == 404
+    assert any(item["id"] == conv_id for item in client.get(f"{BASE}/deleted").json())
+
+
 def test_history_syncs_and_accumulates_in_db(test_client_with_fake_model: TestClient) -> None:
     """Request-authoritative store: the client resends its full history each
     turn; the durable copy is synced to it and the assistant turn appended, so

--- a/mucgpt-core-service/tests/integration/test_conversations_router.py
+++ b/mucgpt-core-service/tests/integration/test_conversations_router.py
@@ -68,6 +68,68 @@ def test_delete_then_404(test_client: TestClient) -> None:
     assert test_client.get(f"{BASE}/{conv_id}").status_code == 404
 
 
+def test_delete_is_soft_and_recreate_returns_409(test_client: TestClient) -> None:
+    """Deleting 404s the chat thereafter; re-creating its id is rejected with
+    409 (anti-resurrection) and writes nothing."""
+    conv_id = test_client.post(BASE, json={"title": "ghost"}).json()["id"]
+
+    assert test_client.delete(f"{BASE}/{conv_id}").status_code == 204
+    assert test_client.get(f"{BASE}/{conv_id}").status_code == 404
+
+    recreate = test_client.post(BASE, json={"id": conv_id, "title": "resurrected"})
+    assert recreate.status_code == 409, recreate.text
+    detail = recreate.json()["detail"]
+    assert detail["conversation_id"] == conv_id
+
+    # The 409 wrote nothing: the chat stays gone (still 404, not "resurrected").
+    assert test_client.get(f"{BASE}/{conv_id}").status_code == 404
+    assert all(c["id"] != conv_id for c in test_client.get(BASE).json())
+
+
+def test_tombstone_feed_lists_deleted_with_since_cursor(test_client: TestClient) -> None:
+    first = test_client.post(BASE, json={"title": "one"}).json()["id"]
+    second = test_client.post(BASE, json={"title": "two"}).json()["id"]
+    assert test_client.delete(f"{BASE}/{first}").status_code == 204
+    assert test_client.delete(f"{BASE}/{second}").status_code == 204
+
+    feed = test_client.get(f"{BASE}/deleted")
+    assert feed.status_code == 200, feed.text
+    ids = {item["id"] for item in feed.json()}
+    assert {first, second} <= ids
+
+    # since=<first tombstone's deleted_at> returns only strictly-newer ones.
+    items = sorted(feed.json(), key=lambda i: i["deleted_at"])
+    cursor = items[0]["deleted_at"]
+    newer = test_client.get(f"{BASE}/deleted", params={"since": cursor})
+    assert newer.status_code == 200
+    newer_ids = {item["id"] for item in newer.json()}
+    assert items[0]["id"] not in newer_ids
+
+
+def test_tombstone_feed_is_owner_scoped(test_client: TestClient) -> None:
+    """One user's tombstones never leak into another user's feed."""
+    conv_id = test_client.post(BASE, json={"title": "mine"}).json()["id"]
+    assert test_client.delete(f"{BASE}/{conv_id}").status_code == 204
+
+    async def _other_user() -> AuthenticationResult:
+        return AuthenticationResult(
+            token="t",
+            user_id="other_user_777",
+            name="Other",
+            email="other@example.com",
+            department="X",
+            is_authenticated=True,
+        )
+
+    api_app.dependency_overrides[authenticate_user] = _other_user
+    try:
+        feed = test_client.get(f"{BASE}/deleted")
+        assert feed.status_code == 200
+        assert all(item["id"] != conv_id for item in feed.json())
+    finally:
+        pass
+
+
 def test_cross_user_isolation(test_client: TestClient) -> None:
     """A conversation created by user A is invisible to user B."""
     conv_id = test_client.post(BASE, json={"title": "private"}).json()["id"]

--- a/mucgpt-core-service/tests/unit/test_conversation_repo.py
+++ b/mucgpt-core-service/tests/unit/test_conversation_repo.py
@@ -3,11 +3,16 @@
 No model endpoint or network involved — pure persistence-layer validation.
 """
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from database.conversation_repo import ConversationRepository
+from database.conversation_repo import (
+    ConversationDeletedError,
+    ConversationRepository,
+)
 from database.models import Message
 
 USER_A = "user-a"
@@ -217,7 +222,7 @@ async def test_update_meta(db_session: AsyncSession) -> None:
 
 
 @pytest.mark.asyncio
-async def test_delete_cascades_messages_and_enforces_ownership(db_session: AsyncSession) -> None:
+async def test_soft_delete_retains_row_and_messages_and_enforces_ownership(db_session: AsyncSession) -> None:
     repo = ConversationRepository(db_session)
     conv = await repo.create(
         user_id=USER_A, messages=[("user", "a"), ("assistant", "b")]
@@ -230,8 +235,103 @@ async def test_delete_cascades_messages_and_enforces_ownership(db_session: Async
     assert await repo.delete(conv.id, USER_A) is True
     await db_session.commit()
 
+    # The chat reads as gone from every normal path...
     assert await repo.get_for_user(conv.id, USER_A) is None
+    assert all(c.id != conv.id for c in await repo.list_for_user(USER_A))
+
+    # ...but soft delete retains the row and its messages (hidden with the
+    # parent; the retention sweep removes both together later).
+    tombstoned = await repo._get_any(conv.id, USER_A)
+    assert tombstoned is not None and tombstoned.deleted_at is not None
     remaining = await db_session.scalar(
         select(func.count()).select_from(Message)
     )
-    assert remaining == 0
+    assert remaining == 2
+
+
+@pytest.mark.asyncio
+async def test_delete_is_idempotent_and_preserves_first_timestamp(db_session: AsyncSession) -> None:
+    repo = ConversationRepository(db_session)
+    conv = await repo.create(user_id=USER_A, title="temp")
+    await db_session.commit()
+
+    assert await repo.delete(conv.id, USER_A) is True
+    await db_session.commit()
+    first_ts = (await repo._get_any(conv.id, USER_A)).deleted_at
+
+    # Deleting an already-tombstoned chat is a no-op that still returns True and
+    # does not re-stamp deleted_at (so the retention/cursor window is stable).
+    assert await repo.delete(conv.id, USER_A) is True
+    await db_session.commit()
+    assert (await repo._get_any(conv.id, USER_A)).deleted_at == first_ts
+
+
+@pytest.mark.asyncio
+async def test_create_with_tombstoned_id_is_rejected_not_resurrected(db_session: AsyncSession) -> None:
+    repo = ConversationRepository(db_session)
+    await repo.create(
+        user_id=USER_A, conversation_id="ghost", messages=[("user", "hi")]
+    )
+    await db_session.commit()
+    assert await repo.delete("ghost", USER_A) is True
+    await db_session.commit()
+
+    with pytest.raises(ConversationDeletedError):
+        await repo.create(user_id=USER_A, conversation_id="ghost")
+
+    # Nothing was written: the row stays tombstoned with its original message.
+    still = await repo._get_any("ghost", USER_A)
+    assert still is not None and still.deleted_at is not None
+    assert [m.content for m in still.messages] == ["hi"]
+
+    # A brand-new id is unaffected by the guard.
+    fresh = await repo.create(user_id=USER_A, conversation_id="brand-new")
+    await db_session.commit()
+    assert fresh.id == "brand-new"
+
+
+@pytest.mark.asyncio
+async def test_writes_to_tombstoned_id_fail_closed(db_session: AsyncSession) -> None:
+    repo = ConversationRepository(db_session)
+    conv = await repo.create(user_id=USER_A, messages=[("user", "hi")])
+    await db_session.commit()
+    assert await repo.delete(conv.id, USER_A) is True
+    await db_session.commit()
+
+    # Both writes go through get_for_user, which now hides the tombstone, so a
+    # deleted chat can never be appended to or rewritten.
+    assert await repo.replace_messages(conv.id, USER_A, [("user", "x")]) is None
+    assert (
+        await repo.append_message(conv.id, USER_A, role="user", content="x")
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_deleted_for_user_filters_and_respects_since(db_session: AsyncSession) -> None:
+    repo = ConversationRepository(db_session)
+    live = await repo.create(user_id=USER_A, conversation_id="live")
+    c1 = await repo.create(user_id=USER_A, conversation_id="d1")
+    c2 = await repo.create(user_id=USER_A, conversation_id="d2")
+    other = await repo.create(user_id=USER_B, conversation_id="d-other")
+    await db_session.commit()
+
+    # Stamp explicit, distinct timestamps: func.now() on SQLite is only
+    # second-granularity, so two deletes in one test can collide and make the
+    # `since` cursor flake. Setting them directly keeps the ordering crisp.
+    t0 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    (await repo._get_any("d1", USER_A)).deleted_at = t0
+    (await repo._get_any("d2", USER_A)).deleted_at = t0 + timedelta(minutes=5)
+    (await repo._get_any("d-other", USER_B)).deleted_at = t0
+    await db_session.flush()
+    await db_session.commit()
+    assert live.id and c1.id and c2.id and other.id  # silence unused warnings
+
+    # Full feed: only the user's tombstones, oldest-deleted first; live + other
+    # user's tombstone never leak.
+    deleted = await repo.list_deleted_for_user(USER_A)
+    assert [c.id for c in deleted] == ["d1", "d2"]
+
+    # since-cursor: only tombstones strictly newer than the cursor come back.
+    newer = await repo.list_deleted_for_user(USER_A, since=t0)
+    assert [c.id for c in newer] == ["d2"]

--- a/mucgpt-frontend/src/api/conversations-client.ts
+++ b/mucgpt-frontend/src/api/conversations-client.ts
@@ -1,5 +1,5 @@
 import { deleteConfig, getConfig, handleApiRequest, patchConfig, postConfig } from "./fetch-utils";
-import { ConversationDetail, ConversationSummary, CreateConversationRequest, UpdateConversationRequest } from "./models";
+import { ConversationDetail, ConversationSummary, CreateConversationRequest, DeletedConversation, UpdateConversationRequest } from "./models";
 
 const CONVERSATIONS_BASE = "/api/backend/v1/conversations";
 
@@ -9,6 +9,17 @@ const CONVERSATIONS_BASE = "/api/backend/v1/conversations";
  */
 export async function listConversations(): Promise<ConversationSummary[]> {
     return handleApiRequest(() => fetch(CONVERSATIONS_BASE, getConfig()), "Failed to list conversations");
+}
+
+/**
+ * Fetch the tombstone feed: ids the user deleted (on any device), oldest-deleted
+ * first. The sync layer applies these by removing the chats locally instead of
+ * re-pushing them. Pass the max `deleted_at` already applied as `since` for
+ * incremental sync; omit it to fetch the full current tombstone set.
+ */
+export async function listDeletedConversations(since?: string): Promise<DeletedConversation[]> {
+    const url = since ? `${CONVERSATIONS_BASE}/deleted?since=${encodeURIComponent(since)}` : `${CONVERSATIONS_BASE}/deleted`;
+    return handleApiRequest(() => fetch(url, getConfig()), "Failed to list deleted conversations");
 }
 
 /** Fetch a single conversation including its ordered messages. */

--- a/mucgpt-frontend/src/api/models.ts
+++ b/mucgpt-frontend/src/api/models.ts
@@ -82,6 +82,16 @@ export interface UpdateConversationRequest {
     favorite?: boolean;
 }
 
+/**
+ * Tombstone-feed item: a conversation the user deleted (on any device).
+ * Mirrors the backend model. `deleted_at` is an ISO-8601 string and doubles as
+ * the incremental-sync cursor.
+ */
+export interface DeletedConversation {
+    id: string;
+    deleted_at: string;
+}
+
 export type CreateAssistantRequest = {
     input: string;
     model?: string;

--- a/mucgpt-frontend/src/components/UnifiedHistory/unifiedHistoryStorage.ts
+++ b/mucgpt-frontend/src/components/UnifiedHistory/unifiedHistoryStorage.ts
@@ -3,7 +3,14 @@ import { StorageService, type DBObject, type DBMessage } from "../../service/sto
 import { ASSISTANT_STORE, CHAT_STORE, CREATIVITY_MEDIUM } from "../../constants";
 import type { Assistant, ChatResponse, ConversationMessage } from "../../api";
 import { getOwnedCommunityAssistants } from "../../api/assistant-client";
-import { createConversation, deleteConversation, getConversation, listConversations, patchConversation } from "../../api/conversations-client";
+import {
+    createConversation,
+    deleteConversation,
+    getConversation,
+    listConversations,
+    listDeletedConversations,
+    patchConversation
+} from "../../api/conversations-client";
 
 /** Pair backend (role, content) messages back into the local user→response shape. */
 const backendMessagesToDbMessages = (messages: ConversationMessage[]): DBMessage<ChatResponse>[] => {
@@ -136,10 +143,24 @@ export class UnifiedHistoryStorage {
     }
 
     private async runSync(): Promise<void> {
-        const [backendList, localChats] = await Promise.all([listConversations(), this.chatStorage.getAll()]);
+        const [backendList, localChats, tombstones] = await Promise.all([
+            listConversations(),
+            this.chatStorage.getAll(),
+            // Best-effort: a missing/failing tombstone feed (e.g. an older
+            // backend without the endpoint) degrades to "no remote deletions to
+            // apply" rather than breaking the whole pull/push sync.
+            listDeletedConversations().catch(error => {
+                console.error("Failed to fetch deletion tombstones", error);
+                return [];
+            })
+        ]);
         const local = localChats ?? [];
         const localIds = new Set(local.filter(chat => chat.id).map(chat => chat.id as string));
         const backendIds = new Set(backendList.map(conversation => conversation.id));
+        // Ids deleted on the backend (this or another device). They must be
+        // dropped locally and never re-pushed — this is what stops the
+        // cross-device resurrection loop.
+        const deletedIds = new Set(tombstones.map(tombstone => tombstone.id));
 
         // Count per-conversation failures so a transient pull/push error makes
         // the whole sync fail (below). Otherwise runSync would resolve despite
@@ -147,8 +168,24 @@ export class UnifiedHistoryStorage {
         // until reload, leaving a chat unpulled or unmigrated.
         let failures = 0;
 
+        // Apply remote deletions first: drop every local chat that is now
+        // tombstoned on the backend. This is how a delete on device A reaches
+        // device B. Failures retry on the next refresh (same `failures` tally).
+        const deletions = local
+            .filter(chat => chat.id && deletedIds.has(chat.id))
+            .map(async chat => {
+                try {
+                    await this.chatStorage.delete(chat.id as string);
+                } catch (error) {
+                    failures++;
+                    console.error(`Failed to apply remote deletion for chat "${chat.id}"`, error);
+                }
+            });
+
         const pulls = backendList
-            .filter(conversation => !localIds.has(conversation.id))
+            // A tombstoned id is never in the backend list, but guard anyway so
+            // a deletion landing mid-sync can't be pulled back in.
+            .filter(conversation => !localIds.has(conversation.id) && !deletedIds.has(conversation.id))
             .map(async conversation => {
                 try {
                     const detail = await getConversation(conversation.id);
@@ -166,7 +203,10 @@ export class UnifiedHistoryStorage {
             });
 
         const pushes = local
-            .filter(chat => chat.id && !backendIds.has(chat.id))
+            // Don't resurrect: a chat that is missing from the backend but
+            // tombstoned was deleted, not "not yet migrated" — skip the push
+            // (it's also deleted locally above; the backend would 409 anyway).
+            .filter(chat => chat.id && !backendIds.has(chat.id) && !deletedIds.has(chat.id))
             .map(async chat => {
                 try {
                     await createConversation({
@@ -180,10 +220,11 @@ export class UnifiedHistoryStorage {
                 }
             });
 
-        // Run all pulls/pushes to completion (one failure must not abort the
-        // others) but surface an aggregate failure so syncWithBackend() clears
-        // the cached promise and a later refresh retries the leftovers.
-        await Promise.all([...pulls, ...pushes]);
+        // Run all deletions/pulls/pushes to completion (one failure must not
+        // abort the others) but surface an aggregate failure so
+        // syncWithBackend() clears the cached promise and a later refresh
+        // retries the leftovers.
+        await Promise.all([...deletions, ...pulls, ...pushes]);
 
         if (failures > 0) {
             throw new Error(`Conversation sync finished with ${failures} failed operation(s); will retry on next refresh`);
@@ -218,8 +259,16 @@ export class UnifiedHistoryStorage {
         if (!deleted) {
             throw new Error(`Failed to delete chat history entry "${entry.id}"`);
         }
-        // Mirror the deletion to the backend (best-effort).
+        // Mirror the deletion to the backend, writing a tombstone (best-effort).
+        // If this fails the chat is already gone locally; it will reappear on a
+        // later sync (the backend row is still live) and the user can re-delete
+        // — an accepted, bounded degradation, never silent data loss.
         await deleteConversation(entry.id).catch(error => console.error(`Failed to delete conversation "${entry.id}" on backend`, error));
+        // Invalidate the once-per-instance sync guard so the next history read
+        // re-syncs against fresh state (including this new tombstone) instead of
+        // reusing a resolved promise built from pre-delete data — which could
+        // otherwise re-pull the just-deleted chat.
+        this.syncPromise = null;
     }
 
     async renameEntry(entry: UnifiedHistoryEntry, name: string): Promise<void> {

--- a/mucgpt-frontend/src/mocks/handlers.ts
+++ b/mucgpt-frontend/src/mocks/handlers.ts
@@ -437,6 +437,12 @@ export const handlers = [
         }
         return HttpResponse.json(node.children || []);
     }),
+    // Tombstone feed for cross-device deletion sync. No backend in mocked dev
+    // mode, so default to an empty feed (no remote deletions to apply); the
+    // `since` cursor is accepted and ignored.
+    http.get("/api/backend/v1/conversations/deleted", () => {
+        return HttpResponse.json([]);
+    }),
     http.get("/api/backend/v1/tools", ({ request }) => {
         const url = new URL(request.url);
         const lang = url.searchParams.get("lang") || "deutsch";


### PR DESCRIPTION
Tracks **it-at-m/mucgpt#1069** (follow-up to PR #1067). Targets the
`feat/state-persistancy-in-backend` branch (PR #1067) so the diff is just the
tombstone work; rebase onto `main` once #1067 merges.

## Problem
Server-side delete was a **hard delete**, and the frontend reconcile pushes any
local chat missing from the backend as a "migration". Together they form a
**resurrection loop**: device A deletes chat *X* → device B still has *X* and
re-creates it on its next sync → A pulls it back. Deletes never stuck across
devices, and B had no way to *learn* A had deleted *X*.

## Approach — soft-delete tombstones
- `Conversation` gains a nullable `deleted_at` (`NULL` = live, timestamp =
  deleted). `DELETE` stamps it instead of removing the row.
- Reads (`GET /{id}`, list) **exclude** tombstones → a deleted chat 404s / is
  absent, exactly as before.
- **Re-creating a tombstoned id is rejected with 409** — on both the CRUD
  `POST /v1/conversations` and the chat-completion auto-create path — killing
  the push-back at the source.
- A **tombstone feed** (`GET /v1/conversations/deleted?since=`) lets clients
  *learn* which ids were deleted and drop them locally instead of re-pushing.

Net effect: a delete on any device propagates; no client can resurrect a chat
it merely still caches.

## Changes
**Backend** — `deleted_at` column; soft + idempotent `delete()`; tombstone-
excluding reads; `ConversationDeletedError` resurrection guard (409 on both
create paths); `list_deleted_for_user(since)` + feed endpoint; tombstone-aware
API models.

**Frontend** — `listDeletedConversations` client + type + MSW handler; `runSync`
applies remote deletions and excludes tombstoned ids from the push set;
`deleteEntry` invalidates the sync guard to close the local re-pull race.

**Docs** — `CHAT_PERSISTENCE.md`: soft-delete semantics, the manual `ALTER TABLE
... ADD COLUMN deleted_at` migration for existing DBs (`create_all` won't add
it), and a retention/pruning policy.

## Tests
`100 passed, 5 skipped`; `ruff` clean; frontend `lint` + `build` clean. New
coverage: soft delete retains row/messages, idempotent delete, fail-closed
writes to a tombstoned id, **409-on-resurrect on both the CRUD and chat paths
(writes nothing)**, and the owner-scoped feed with `since`-cursor.

## Scope notes
- **Frontend deletion-sync tests (roadmap step 11) deferred:** the frontend has
  no test framework yet; adding one was out of scope for this MR. Backend tests
  cover the core contract.
- The branch also carries the planning `roadmaps/` markdown (came in with commit
  `627cf265`) for chat-persistence + optimistic-concurrency + deletion-tombstones
  — unrelated to this change, flagged for the reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)