### PR TITLE
✨ Optimistic-concurrency guard for cross-device chat turns

### DIFF
--- a/CHAT_PERSISTENCE.md
+++ b/CHAT_PERSISTENCE.md
@@ -199,6 +199,61 @@ MUCGPT_CORE_DB__NAME=mucgpt
 - **Rollback:** reverting the frontend leaves the new tables unused but harmless; there is
   no destructive migration.
 
+## Optimistic concurrency (cross-device conflict guard)
+
+Because every turn rewrites the stored conversation to the client's snapshot
+(`replace_messages`) before appending the assistant turn, the same chat open on
+two devices could **silently lose turns** (last-write-wins). A server-owned
+revision rejects a turn based on a **stale completed revision** — the common
+**sequential** cross-device case (device B finishes a turn, device A then sends
+based on the pre-B revision → 409 → reconcile).
+
+> **Residual (known, out of scope):** two turns generating *simultaneously* are
+> not caught — both run `replace_messages` (which overwrites but does **not**
+> bump) before either appends, so neither sees the other's bump. Bumping on
+> `replace` too would catch this but would falsely 409 every failed-generation
+> retry; for a chat app, protecting the sequential case while never punishing a
+> retry is the deliberate tradeoff. Merge-on-conflict is also out of scope.
+
+- **`conversations.revision`** — a monotonic integer, server-owned. Bumped by
+  **exactly one per persisted turn**, only in `append_message` (not in
+  `replace_messages`), so a turn that fails *after* the history sync advances
+  nothing and the client's own retry is never falsely rejected.
+- **Request:** the client may send `conversation_revision` (the revision its
+  history is based on) on `POST /v1/chat/completions`. It is **optional** — omit
+  it (e.g. a brand-new chat) and the precondition check is skipped, exactly
+  today's behavior.
+- **Conflict:** if the stored revision has moved past the supplied value, the
+  turn is rejected with **HTTP 409** carrying a `ConversationConflict` body
+  (`detail`, `current_revision`, `expected_revision`). The rejection happens
+  **before any model call** — no generation is spent and nothing is written.
+- **New revision back to the client:**
+  - non-streaming: `conversation_revision` on the response body;
+  - streaming: a final SSE event after the terminal `stop` chunk —
+    `data: {"object": "conversation.revision", "conversation_revision": <int>}` —
+    emitted only on a successful turn (never on a failed/aborted stream).
+  `revision` is also returned on conversation read/create models so a freshly
+  pulled or created chat starts with the correct precondition.
+- **Client behavior on 409:** pull the authoritative history
+  (`GET /v1/conversations/{id}`), replace local messages + revision, show a
+  non-blocking notice, and preserve the unsent prompt. **No auto-resend** (avoids
+  duplicate turns); the user resends with the refreshed revision.
+
+**Production migration.** `create_all` adds `revision` only to *fresh* DBs. For an
+existing Postgres deployment, apply the column before deploy:
+
+```sql
+ALTER TABLE conversations ADD COLUMN revision INTEGER NOT NULL DEFAULT 0;
+```
+
+core-service has no Alembic yet (only `mucgpt-assistant-service-migrations/`);
+run this DDL manually in the deploy runbook, or add it as the first revision if
+core-service later adopts Alembic.
+
+**Rollout is backend-first and safe.** The guard is opt-in per request: no client
+sends `conversation_revision` until the frontend ships, so 409s cannot occur
+prematurely. (Related: issue #1069 cross-device deletion tombstones.)
+
 ## How it was verified
 
 - Automated: repository, router, and end-to-end persistence suites plus the

--- a/mucgpt-core-service/app/api/api_models.py
+++ b/mucgpt-core-service/app/api/api_models.py
@@ -103,6 +103,16 @@ class ChatCompletionRequest(BaseModel):
             "stateless (current default behavior)."
         ),
     )
+    conversation_revision: int | None = Field(
+        None,
+        description=(
+            "Revision the client's history is based on. Enables optimistic-"
+            "concurrency rejection: if the stored conversation has advanced past "
+            "this revision (another tab/device appended a turn), the request is "
+            "rejected with HTTP 409 instead of overwriting the newer history. "
+            "Omit it (e.g. a brand-new chat) to skip the check entirely."
+        ),
+    )
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
@@ -179,6 +189,16 @@ class ChatCompletionResponse(BaseModel):
         ..., description="List of completion choices"
     )
     usage: Usage = Field(..., description="Token usage information")
+    conversation_revision: int | None = Field(
+        None,
+        description=(
+            "The conversation's new revision after this turn was persisted. "
+            "Populated only when the request carried a conversation_id (the chat "
+            "is server-persisted); null for stateless requests. The streaming "
+            "path delivers this via a final SSE event instead (see the "
+            "/chat/completions route docs)."
+        ),
+    )
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
@@ -469,6 +489,14 @@ class ConversationSummary(BaseModel):
     model: str | None = None
     created_at: datetime
     updated_at: datetime
+    revision: int = Field(
+        0,
+        description=(
+            "Server-owned optimistic-concurrency revision. The client sends this "
+            "back as conversation_revision on the next chat turn to detect stale "
+            "cross-device overwrites."
+        ),
+    )
     model_config = ConfigDict(from_attributes=True)
 
 
@@ -477,6 +505,30 @@ class ConversationDetail(ConversationSummary):
 
     messages: list[ChatCompletionMessage] = Field(default_factory=list)
     model_config = ConfigDict(from_attributes=True)
+
+
+class ConversationConflict(BaseModel):
+    """409 body for an optimistic-concurrency rejection on a chat turn."""
+
+    detail: str = Field(
+        "Conversation was modified by another client; reload and retry.",
+        description="Human-readable explanation of the conflict.",
+    )
+    current_revision: int = Field(
+        ..., description="The conversation's current server-side revision."
+    )
+    expected_revision: int = Field(
+        ..., description="The revision the rejected request was based on."
+    )
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "detail": "Conversation was modified by another client; reload and retry.",
+                "current_revision": 5,
+                "expected_revision": 4,
+            }
+        }
+    )
 
 
 class CreateConversationRequest(BaseModel):

--- a/mucgpt-core-service/app/api/routers/chat_router.py
+++ b/mucgpt-core-service/app/api/routers/chat_router.py
@@ -8,6 +8,7 @@ from api.api_models import (
     ChatCompletionMessage,
     ChatCompletionRequest,
     ChatCompletionResponse,
+    ConversationConflict,
     CreateAssistantRequest,
     CreateAssistantResult,
 )
@@ -16,7 +17,7 @@ from config.settings import get_settings
 from core.auth import authenticate_user
 from core.auth_models import AuthenticationResult
 from core.logtools import getLogger
-from database.conversation_repo import ConversationRepository
+from database.conversation_repo import ConflictError, ConversationRepository
 from database.session import get_db_session
 from init_app import init_agent
 
@@ -87,6 +88,15 @@ def get_temperature_from_request(request: ChatCompletionRequest) -> float:
     response_model=ChatCompletionResponse,
     responses={
         200: {"description": "Successful Response"},
+        409: {
+            "model": ConversationConflict,
+            "description": (
+                "Optimistic-concurrency conflict: the conversation was modified "
+                "by another client since the revision this request was based on. "
+                "No model call is made and nothing is persisted; the client "
+                "should reload the conversation and retry."
+            ),
+        },
         500: {"description": "Internal Server Error"},
     },
 )
@@ -101,6 +111,17 @@ async def chat_completions(
     When ``conversation_id`` is supplied, the incoming user message and the
     produced assistant message are persisted to that conversation. Without it,
     the request is fully stateless (unchanged legacy behavior).
+
+    Optimistic concurrency: when ``conversation_revision`` is also supplied, the
+    history sync is rejected with **HTTP 409** (``ConversationConflict`` body) if
+    the stored conversation has advanced past that revision — before any model
+    call, so a stale cross-device turn neither overwrites newer history nor
+    spends a generation. The new revision is returned to the client:
+      - non-streaming: ``conversation_revision`` on the response body;
+      - streaming: a final SSE event
+        ``data: {"object": "conversation.revision", "conversation_revision": <int>}``
+        emitted after the terminal ``finish_reason: "stop"`` chunk (and only on a
+        successful turn — failed/aborted streams emit no revision event).
     """
     # TODO: init_agent currently rebuilds the tool collection and LangChain agent
     # for every message, even within the same chat. Consider introducing a
@@ -128,12 +149,27 @@ async def chat_completions(
                 assistant_id=request.assistant_id,
             )
         # Sync the stored history to the (authoritative) request history,
-        # including the incoming user turn, before invoking the agent.
-        await repo.replace_messages(
-            conversation_id,
-            user_info.user_id,
-            _storable_messages(request.messages),
-        )
+        # including the incoming user turn, before invoking the agent. The
+        # optimistic-concurrency precondition runs here, before any model call:
+        # a stale cross-device turn is rejected with 409 and nothing is written
+        # or generated. Mapping ConflictError here (outside the main try/except
+        # below) keeps the 409 from being reconverted into a 500.
+        try:
+            await repo.replace_messages(
+                conversation_id,
+                user_info.user_id,
+                _storable_messages(request.messages),
+                expected_revision=request.conversation_revision,
+            )
+        except ConflictError as conflict:
+            await session.rollback()
+            raise HTTPException(
+                status_code=409,
+                detail=ConversationConflict(
+                    current_revision=conflict.current_revision,
+                    expected_revision=conflict.expected_revision,
+                ).model_dump(),
+            )
         await session.commit()
 
     try:
@@ -163,6 +199,7 @@ async def chat_completions(
             async def sse_generator():
                 assistant_content: list[str] = []
                 stream_failed = False
+                new_revision: int | None = None
                 try:
                     async for chunk in gen:
                         # Accumulate assistant text deltas for persistence.
@@ -183,7 +220,9 @@ async def chat_completions(
                     # ends (also runs if the client disconnects mid-stream, so
                     # whatever arrived is saved). Skip persistence when the run
                     # surfaced an error so failed generations are not written to
-                    # the durable log and echoed back on the next sync.
+                    # the durable log and echoed back on the next sync. No yield
+                    # here: this also runs under GeneratorExit (client gone),
+                    # where yielding would raise.
                     if repo is not None and assistant_content and not stream_failed:
                         await repo.append_message(
                             conversation_id,
@@ -192,6 +231,26 @@ async def chat_completions(
                             content="".join(assistant_content),
                         )
                         await session.commit()
+                        new_revision = await repo.current_revision(
+                            conversation_id, user_info.user_id
+                        )
+
+                # Emit the post-turn revision as a final event. Reached only on
+                # normal completion: a client disconnect propagates GeneratorExit
+                # past the finally and skips this, so we never yield into a
+                # closing generator. Gated by new_revision (set only on a
+                # successful, persisted turn).
+                if new_revision is not None:
+                    yield (
+                        "data: "
+                        + json.dumps(
+                            {
+                                "object": "conversation.revision",
+                                "conversation_revision": new_revision,
+                            }
+                        )
+                        + "\n\n"
+                    )
 
             return StreamingResponse(sse_generator(), media_type="text/event-stream")
         else:
@@ -219,6 +278,11 @@ async def chat_completions(
                     content=response.choices[0].message.content,
                 )
                 await session.commit()
+                # Surface the post-turn revision so the client can send it as the
+                # precondition on its next turn.
+                response.conversation_revision = await repo.current_revision(
+                    conversation_id, user_info.user_id
+                )
             return response
     except HTTPException:
         raise

--- a/mucgpt-core-service/app/api/routers/conversations_router.py
+++ b/mucgpt-core-service/app/api/routers/conversations_router.py
@@ -58,6 +58,7 @@ def _to_detail(conversation: Conversation) -> ConversationDetail:
         model=conversation.model,
         created_at=conversation.created_at,
         updated_at=conversation.updated_at,
+        revision=conversation.revision,
         messages=[
             ChatCompletionMessage(role=m.role, content=m.content)
             for m in conversation.messages

--- a/mucgpt-core-service/app/database/conversation_repo.py
+++ b/mucgpt-core-service/app/database/conversation_repo.py
@@ -19,6 +19,25 @@ from database.models import Conversation, Message
 _APPEND_MAX_ATTEMPTS = 5
 
 
+class ConflictError(Exception):
+    """Raised when an optimistic-concurrency precondition fails.
+
+    Distinct from ``IntegrityError`` (the intra-conversation sequence-collision
+    that ``append_message`` retries): this is the *inter-client* precondition
+    failure — another tab/device advanced the stored conversation past the
+    revision the current client's history is based on. The router maps it to
+    HTTP 409 instead of retrying.
+    """
+
+    def __init__(self, *, current_revision: int, expected_revision: int):
+        self.current_revision = current_revision
+        self.expected_revision = expected_revision
+        super().__init__(
+            f"conversation revision mismatch: stored={current_revision} "
+            f"expected={expected_revision}"
+        )
+
+
 class ConversationRepository:
     def __init__(self, session: AsyncSession):
         self.session = session
@@ -114,6 +133,7 @@ class ConversationRepository:
         conversation_id: str,
         user_id: str,
         messages: Iterable[tuple[str, str]],
+        expected_revision: int | None = None,
     ) -> Conversation | None:
         """Replace all stored messages with the given (role, content) sequence.
 
@@ -121,10 +141,31 @@ class ConversationRepository:
         authoritative conversation history each turn (so client-side
         rollback/regenerate edits are mirrored without extra endpoints).
         Returns None if the conversation is not owned by the user.
+
+        Optimistic-concurrency guard: when ``expected_revision`` is supplied and
+        the stored revision has moved on (another tab/device appended a turn the
+        caller has not seen), raise ``ConflictError`` and write nothing rather
+        than silently overwriting the newer history (last-write-wins data loss).
+        When ``expected_revision`` is None the check is skipped and the method
+        behaves exactly as before (backward-compatible, opt-in per request).
+
+        Note: this method does not itself bump ``revision`` — only completed
+        turns advance it, via ``append_message``. So a turn that fails after the
+        sync (no assistant message) leaves the revision untouched and the
+        client's own retry is not falsely rejected.
         """
         conversation = await self.get_for_user(conversation_id, user_id)
         if conversation is None:
             return None
+
+        if (
+            expected_revision is not None
+            and conversation.revision != expected_revision
+        ):
+            raise ConflictError(
+                current_revision=conversation.revision,
+                expected_revision=expected_revision,
+            )
 
         # Clear then flush the deletes first so re-inserting from sequence 0
         # cannot collide with the (conversation_id, sequence) unique constraint.
@@ -195,8 +236,13 @@ class ConversationRepository:
                     raise
                 continue
 
-        # Touch the conversation so updated_at advances (onupdate needs a change).
+        # Touch the conversation so updated_at advances (onupdate needs a change)
+        # and bump the optimistic-concurrency revision: a completed assistant
+        # turn is exactly the content mutation other clients must not clobber.
+        # Bumping here (and not in replace_messages) keeps revision == number of
+        # persisted turns, so a failed turn advances nothing.
         conversation.updated_at = func.now()
+        conversation.revision = conversation.revision + 1
         await self.session.flush()
         # The message was inserted directly (explicit FK), bypassing the loaded
         # ``messages`` collection; reload it so the in-memory conversation stays
@@ -204,3 +250,18 @@ class ConversationRepository:
         await self.session.refresh(conversation, ["messages"])
         await self.session.refresh(message)
         return message
+
+    async def current_revision(
+        self, conversation_id: str, user_id: str
+    ) -> int | None:
+        """Return the conversation's current revision, or None if not owned.
+
+        A lightweight single-column lookup so a caller (the chat router) can
+        surface the post-turn revision without re-loading the full message set.
+        """
+        return await self.session.scalar(
+            select(Conversation.revision).where(
+                Conversation.id == conversation_id,
+                Conversation.user_id == user_id,
+            )
+        )

--- a/mucgpt-core-service/app/database/models.py
+++ b/mucgpt-core-service/app/database/models.py
@@ -56,6 +56,14 @@ class Conversation(Base):
         onupdate=_utcnow,
         nullable=False,
     )
+    # Server-owned monotonic version for optimistic-concurrency. Bumped on every
+    # content mutation (assistant turn appended); used as the precondition a
+    # client sends to reject stale cross-device overwrites with HTTP 409.
+    # NOTE: create_all only adds this to FRESH databases; existing/Postgres
+    # deployments need the explicit ALTER TABLE migration (see docs/roadmap 12).
+    revision: Mapped[int] = mapped_column(
+        Integer, server_default="0", default=0, nullable=False
+    )
 
     messages: Mapped[list[Message]] = relationship(
         "Message",

--- a/mucgpt-core-service/tests/integration/test_chat_persistence_e2e.py
+++ b/mucgpt-core-service/tests/integration/test_chat_persistence_e2e.py
@@ -68,11 +68,16 @@ def test_streaming_persists_assembled_assistant_once(test_client_with_fake_model
     ) as resp:
         assert resp.status_code == 200, resp.text
         streamed = []
+        revision_event = None
         for line in resp.iter_lines():
             if not line:
                 continue
             payload = line[len("data: ") :] if line.startswith("data: ") else line
             chunk = json.loads(payload)
+            # The final SSE event carries the new revision and has no choices.
+            if chunk.get("object") == "conversation.revision":
+                revision_event = chunk
+                continue
             delta = chunk["choices"][0]["delta"].get("content")
             if delta:
                 streamed.append(delta)
@@ -84,6 +89,10 @@ def test_streaming_persists_assembled_assistant_once(test_client_with_fake_model
     # Exactly one assistant message persisted, equal to the assembled stream.
     assert len(assistant_msgs) == 1
     assert assistant_msgs[0]["content"] == assembled
+    # A successful stream ends with a revision event reflecting the persisted
+    # turn, matching the conversation's stored revision (one completed turn).
+    assert revision_event is not None
+    assert revision_event["conversation_revision"] == detail["revision"] == 1
 
 
 def test_without_conversation_id_is_stateless(test_client_with_fake_model: TestClient) -> None:
@@ -218,6 +227,119 @@ def test_history_sync_mirrors_client_truncation(test_client_with_fake_model: Tes
     roles = [(m["role"], m["content"]) for m in client.get(f"{BASE}/{conv_id}").json()["messages"]]
     assert [r for r, _ in roles] == ["user", "assistant"]
     assert roles[0] == ("user", "u1")
+
+
+def test_non_streaming_revision_roundtrip_and_stale_conflict(
+    test_client_with_fake_model: TestClient,
+) -> None:
+    """A non-streaming turn returns the post-turn revision; sending the matching
+    revision next turn succeeds and advances it; a now-stale revision is 409."""
+    client = test_client_with_fake_model
+    conv_id = _create_conversation(client)
+
+    # Turn 1: no precondition (brand-new chat) -> ok, revision advances to 1.
+    r1 = client.post(
+        CHAT,
+        json={
+            "model": "fake",
+            "messages": [{"role": "user", "content": "first"}],
+            "stream": False,
+            "conversation_id": conv_id,
+        },
+    )
+    assert r1.status_code == 200, r1.text
+    assert r1.json()["conversation_revision"] == 1
+
+    # Turn 2: send the matching revision -> ok, advances to 2.
+    a1 = client.get(f"{BASE}/{conv_id}").json()["messages"][1]["content"]
+    r2 = client.post(
+        CHAT,
+        json={
+            "model": "fake",
+            "messages": [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": a1},
+                {"role": "user", "content": "second"},
+            ],
+            "stream": False,
+            "conversation_id": conv_id,
+            "conversation_revision": 1,
+        },
+    )
+    assert r2.status_code == 200, r2.text
+    assert r2.json()["conversation_revision"] == 2
+
+    # Turn 3: reuse the now-stale revision 1 (simulating another device having
+    # advanced the chat) -> 409 with the conflict body, nothing overwritten.
+    r3 = client.post(
+        CHAT,
+        json={
+            "model": "fake",
+            "messages": [{"role": "user", "content": "stale overwrite"}],
+            "stream": False,
+            "conversation_id": conv_id,
+            "conversation_revision": 1,
+        },
+    )
+    assert r3.status_code == 409, r3.text
+    body = r3.json()["detail"]
+    assert body["current_revision"] == 2
+    assert body["expected_revision"] == 1
+    # The stale request neither overwrote history nor advanced the revision.
+    detail = client.get(f"{BASE}/{conv_id}").json()
+    assert detail["revision"] == 2
+    assert [m["content"] for m in detail["messages"] if m["role"] == "user"] == [
+        "first",
+        "second",
+    ]
+
+
+def test_streaming_stale_revision_returns_409_before_any_chunk(
+    test_client_with_fake_model: TestClient,
+) -> None:
+    """A stale revision on a streaming request is rejected with 409 up front (no
+    stream opened, nothing persisted)."""
+    client = test_client_with_fake_model
+    conv_id = _create_conversation(client)
+
+    # Establish revision 1 with one streamed turn.
+    with client.stream(
+        "POST",
+        CHAT,
+        json={
+            "model": "fake",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+            "conversation_id": conv_id,
+        },
+    ) as resp:
+        assert resp.status_code == 200
+        for _ in resp.iter_lines():
+            pass
+    before = client.get(f"{BASE}/{conv_id}").json()
+    assert before["revision"] == 1
+    assistants_before = len([m for m in before["messages"] if m["role"] == "assistant"])
+
+    # Stale streaming request: 409 is raised before the StreamingResponse, so it
+    # surfaces as a normal JSON error (no SSE body).
+    resp = client.post(
+        CHAT,
+        json={
+            "model": "fake",
+            "messages": [{"role": "user", "content": "stale"}],
+            "stream": True,
+            "conversation_id": conv_id,
+            "conversation_revision": 0,
+        },
+    )
+    assert resp.status_code == 409, resp.text
+    body = resp.json()["detail"]
+    assert body["current_revision"] == 1
+    assert body["expected_revision"] == 0
+
+    after = client.get(f"{BASE}/{conv_id}").json()
+    assert after["revision"] == 1
+    assert len([m for m in after["messages"] if m["role"] == "assistant"]) == assistants_before
 
 
 def test_chat_flow_does_not_engage_checkpointer(test_client_with_fake_model: TestClient) -> None:

--- a/mucgpt-core-service/tests/integration/test_chat_router.py
+++ b/mucgpt-core-service/tests/integration/test_chat_router.py
@@ -407,3 +407,62 @@ class TestChatRouter:
         assert response.usage.prompt_tokens > 0
         assert response.usage.completion_tokens > 0
         assert response.usage.total_tokens > 0
+
+    @patch("api.routers.chat_router.init_agent", new_callable=AsyncMock)
+    def test_stale_revision_returns_409_without_model_call(
+        self, mock_init_agent, test_client: TestClient
+    ):
+        """A turn whose conversation_revision is stale is rejected with 409 and
+        the model is never invoked (reject-before-generate)."""
+        mock_response = ChatCompletionResponse(
+            id="chatcmpl-test123",
+            object="chat.completion",
+            created=1234567890,
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="ok"),
+                    finish_reason="stop",
+                )
+            ],
+            usage=Usage(prompt_tokens=5, completion_tokens=1, total_tokens=6),
+        )
+        mock_agent_executor = Mock(MUCGPTAgentExecutor)
+        # Return the response object (the persistence path reads .choices and
+        # sets .conversation_revision on it).
+        mock_agent_executor.run_without_streaming.return_value = mock_response
+        mock_init_agent.return_value = mock_agent_executor
+
+        conv_id = "conv-conflict-router"
+
+        # Turn 1 (no precondition): auto-creates and advances revision to 1.
+        r1 = test_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": False,
+                "conversation_id": conv_id,
+            },
+        )
+        assert r1.status_code == 200, r1.text
+        assert r1.json()["conversation_revision"] == 1
+
+        mock_agent_executor.run_without_streaming.reset_mock()
+
+        # Turn 2 with the now-stale revision 0: 409, and no generation happened.
+        r2 = test_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "stale"}],
+                "stream": False,
+                "conversation_id": conv_id,
+                "conversation_revision": 0,
+            },
+        )
+        assert r2.status_code == 409, r2.text
+        body = r2.json()["detail"]
+        assert body["current_revision"] == 1
+        assert body["expected_revision"] == 0
+        mock_agent_executor.run_without_streaming.assert_not_called()

--- a/mucgpt-core-service/tests/unit/test_conversation_repo.py
+++ b/mucgpt-core-service/tests/unit/test_conversation_repo.py
@@ -7,7 +7,7 @@ import pytest
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from database.conversation_repo import ConversationRepository
+from database.conversation_repo import ConflictError, ConversationRepository
 from database.models import Message
 
 USER_A = "user-a"
@@ -214,6 +214,90 @@ async def test_update_meta(db_session: AsyncSession) -> None:
     assert again.favorite is True
 
     assert await repo.update_meta(conv.id, USER_B, title="hacked") is None
+
+
+@pytest.mark.asyncio
+async def test_revision_starts_at_zero_and_bumps_only_on_append(
+    db_session: AsyncSession,
+) -> None:
+    """revision == number of persisted turns: a fresh conversation is 0, every
+    append bumps by exactly 1, and neither replace_messages nor update_meta
+    advances it (only completed turns count)."""
+    repo = ConversationRepository(db_session)
+    conv = await repo.create(user_id=USER_A, title="rev")
+    await db_session.commit()
+    assert conv.revision == 0
+
+    # replace_messages syncs client history but does NOT bump (a turn that fails
+    # after the sync must not advance the revision).
+    await repo.replace_messages(conv.id, USER_A, [("user", "u1")])
+    await db_session.commit()
+    assert (await repo.current_revision(conv.id, USER_A)) == 0
+
+    # Metadata-only updates never bump.
+    await repo.update_meta(conv.id, USER_A, title="renamed", favorite=True)
+    await db_session.commit()
+    assert (await repo.current_revision(conv.id, USER_A)) == 0
+
+    # Each append bumps by exactly 1.
+    await repo.append_message(conv.id, USER_A, role="assistant", content="a1")
+    await db_session.commit()
+    assert (await repo.current_revision(conv.id, USER_A)) == 1
+
+    await repo.append_message(conv.id, USER_A, role="user", content="u2")
+    await db_session.commit()
+    assert (await repo.current_revision(conv.id, USER_A)) == 2
+
+
+@pytest.mark.asyncio
+async def test_replace_messages_stale_revision_raises_and_writes_nothing(
+    db_session: AsyncSession,
+) -> None:
+    """A stale expected_revision is a cross-client conflict: ConflictError is
+    raised and the stored history + revision are left untouched."""
+    repo = ConversationRepository(db_session)
+    conv = await repo.create(user_id=USER_A, messages=[("user", "orig")])
+    await db_session.commit()
+    conv_id = conv.id  # capture before the rollback expires the instance
+    # Advance the stored revision so the client's expectation (0) goes stale.
+    await repo.append_message(conv_id, USER_A, role="assistant", content="a1")
+    await db_session.commit()
+    assert (await repo.current_revision(conv_id, USER_A)) == 1
+
+    with pytest.raises(ConflictError) as excinfo:
+        await repo.replace_messages(
+            conv_id, USER_A, [("user", "overwrite")], expected_revision=0
+        )
+    assert excinfo.value.current_revision == 1
+    assert excinfo.value.expected_revision == 0
+
+    await db_session.rollback()
+    fetched = await repo.get_for_user(conv_id, USER_A)
+    # Nothing overwritten; revision unchanged.
+    assert [m.content for m in fetched.messages] == ["orig", "a1"]
+    assert fetched.revision == 1
+
+
+@pytest.mark.asyncio
+async def test_replace_messages_matching_revision_applies(
+    db_session: AsyncSession,
+) -> None:
+    """A matching (or absent) expected_revision applies the write as usual."""
+    repo = ConversationRepository(db_session)
+    conv = await repo.create(user_id=USER_A, messages=[("user", "u1")])
+    await db_session.commit()
+    assert conv.revision == 0
+
+    replaced = await repo.replace_messages(
+        conv.id, USER_A, [("user", "u1"), ("assistant", "a1")], expected_revision=0
+    )
+    await db_session.commit()
+    assert replaced is not None
+
+    fetched = await repo.get_for_user(conv.id, USER_A)
+    assert [m.content for m in fetched.messages] == ["u1", "a1"]
+    # replace_messages itself does not bump the revision.
+    assert fetched.revision == 0
 
 
 @pytest.mark.asyncio

--- a/mucgpt-frontend/src/api/core-client.ts
+++ b/mucgpt-frontend/src/api/core-client.ts
@@ -44,6 +44,9 @@ export async function chatApi(options: ChatRequest): Promise<Response> {
     if (options.conversation_id) {
         body.conversation_id = options.conversation_id;
     }
+    if (options.conversation_revision !== undefined) {
+        body.conversation_revision = options.conversation_revision;
+    }
     return await fetch(url, postConfig(body));
 }
 

--- a/mucgpt-frontend/src/api/models.ts
+++ b/mucgpt-frontend/src/api/models.ts
@@ -45,6 +45,11 @@ export type ChatRequest = {
     // Server-side conversation id. When set, the backend persists this chat's
     // history under it (created on first use), keyed by the authenticated user.
     conversation_id?: string;
+    // Revision the client's history is based on. When set, the backend rejects a
+    // stale cross-device overwrite with HTTP 409 instead of clobbering newer
+    // history. Omitted for brand-new chats (no revision yet) so the first turn is
+    // never falsely rejected.
+    conversation_revision?: number;
 };
 
 // Server-side chat persistence (mirrors the backend conversations API).
@@ -61,6 +66,8 @@ export interface ConversationSummary {
     model?: string | null;
     created_at: string;
     updated_at: string;
+    /** Server-owned optimistic-concurrency revision; sent back as conversation_revision on the next turn. */
+    revision?: number;
 }
 
 export interface ConversationDetail extends ConversationSummary {

--- a/mucgpt-frontend/src/components/UnifiedHistory/unifiedHistoryStorage.ts
+++ b/mucgpt-frontend/src/components/UnifiedHistory/unifiedHistoryStorage.ts
@@ -159,6 +159,9 @@ export class UnifiedHistoryStorage {
                         detail.title ?? undefined,
                         detail.favorite
                     );
+                    // Start the local copy at the server's current revision so the
+                    // next turn sends an accurate optimistic-concurrency precondition.
+                    await this.chatStorage.setRevision(detail.id, detail.revision);
                 } catch (error) {
                     failures++;
                     console.error(`Failed to pull conversation "${conversation.id}" from backend`, error);

--- a/mucgpt-frontend/src/i18n.ts
+++ b/mucgpt-frontend/src/i18n.ts
@@ -58,6 +58,9 @@ i18n
                         prompt: "Stelle eine Frage oder lade ein Dokument hoch",
                         prompt_no_upload: "Stelle eine Frage",
                         answer_loading: "Erstelle Antwort",
+                        conflict_title: "Chat anderswo aktualisiert",
+                        conflict_message:
+                            "Dieser Chat wurde auf einem anderen Gerät aktualisiert. Die neueste Version wurde geladen – bitte sende deine Nachricht erneut.",
                         follow_up_actions: {
                             shorter_tooltip: "Schreibe eine kürzere Antwort",
                             longer_tooltip: "Schreibe eine längere Antwort",
@@ -814,6 +817,8 @@ i18n
                         prompt: "Ask a question or upload a document",
                         prompt_no_upload: "Ask a question",
                         answer_loading: "Generating answer",
+                        conflict_title: "Chat updated elsewhere",
+                        conflict_message: "This chat was updated on another device. The latest version has been loaded — please resend your message.",
                         follow_up_actions: {
                             shorter_tooltip: "Shorten your answer",
                             longer_tooltip: "Write a longer response",

--- a/mucgpt-frontend/src/pages/chat/Chat.tsx
+++ b/mucgpt-frontend/src/pages/chat/Chat.tsx
@@ -12,7 +12,8 @@ import { CHAT_STORE, CREATIVITY_LOW } from "../../constants";
 import { DBMessage, StorageService } from "../../service/storage";
 import { AnswerList } from "../../components/AnswerList/AnswerList";
 import { FollowUpActionContext } from "../../components/FollowUpAction";
-import { getChatReducer, handleRegenerate, handleRollback, makeApiRequest } from "../page_helpers";
+import { ConversationConflictError, getChatReducer, handleRegenerate, handleRollback, makeApiRequest } from "../page_helpers";
+import { useGlobalToastContext } from "../../components/GlobalToastHandler/GlobalToastContext";
 import { STORAGE_KEYS } from "../layout/LayoutHelper";
 import { ToolStatus } from "../../utils/ToolStreamHandler";
 import { Model } from "../../api";
@@ -117,6 +118,7 @@ const Chat = () => {
     const [isLoading, setIsLoading] = useState<boolean>(false);
 
     useToolStatusToasts(toolStatuses);
+    const { showWarning } = useGlobalToastContext();
 
     // Related states with useReducer
     const [chatState, dispatch] = useReducer(chatReducer, {
@@ -288,12 +290,21 @@ const Chat = () => {
                     setLoadingState
                 );
             } catch (e) {
-                setError(e);
+                if (e instanceof ConversationConflictError) {
+                    // The turn was rejected because the chat changed on another
+                    // device; makeApiRequest already reloaded the authoritative
+                    // history. Restore the user's unsent prompt and tell them to
+                    // resend (no auto-resend, to avoid duplicate turns).
+                    setQuestion(question);
+                    showWarning(t("chat.conflict_title"), t("chat.conflict_message"));
+                } else {
+                    setError(e);
+                }
             } finally {
                 setLoadingState(false);
             }
         },
-        [answers, creativity, LLM, storageService, fetchHistory, selectedTools, setToolStatuses, setLoadingState]
+        [answers, creativity, LLM, storageService, fetchHistory, selectedTools, setToolStatuses, setLoadingState, showWarning, t]
     );
 
     // Regenerate-Funktion

--- a/mucgpt-frontend/src/pages/page_helpers.ts
+++ b/mucgpt-frontend/src/pages/page_helpers.ts
@@ -2,7 +2,7 @@ import { MutableRefObject, Dispatch, SetStateAction } from "react";
 import { DBMessage, StorageService } from "../service/storage";
 import { DBObject } from "../service/storage";
 import { ChatMessage, ChatOptions } from "./chat/Chat";
-import { ChatRequest, ChatResponse, ChatTurn, DataSource } from "../api";
+import { ChatRequest, ChatResponse, ChatTurn, ConversationMessage, DataSource } from "../api";
 import { ChatCompletionChunk, ChatCompletionChunkChoice } from "../api/models";
 import { ToolStreamHandler, ToolStatus } from "../utils/ToolStreamHandler";
 
@@ -11,7 +11,62 @@ import { AssistantStorageService } from "../service/assistantstorage";
 import { v4 as uuid } from "uuid";
 import { handleRedirect } from "../api/fetch-utils";
 import { createChatName } from "../api/core-client";
-import { deleteConversation, patchConversation } from "../api/conversations-client";
+import { deleteConversation, getConversation, patchConversation } from "../api/conversations-client";
+
+/**
+ * Thrown by makeApiRequest when the backend rejects a chat turn with HTTP 409
+ * (optimistic-concurrency conflict: the chat was modified on another device).
+ * makeApiRequest has already reloaded the authoritative server history into the
+ * store and UI; the caller catches this to surface a non-blocking notice and
+ * restore the user's unsent input so they can resend (no auto-resend).
+ */
+export class ConversationConflictError extends Error {
+    constructor(public readonly conversationId: string) {
+        super("Conversation was modified by another client");
+        this.name = "ConversationConflictError";
+    }
+}
+
+/** Pair backend (role, content) messages into the chat page's user→response turns. */
+export const backendMessagesToAnswers = (messages: ConversationMessage[]): ChatMessage[] => {
+    const result: ChatMessage[] = [];
+    let pendingUser: string | null = null;
+    for (const message of messages) {
+        if (message.role === "system") continue;
+        if (message.role === "user") {
+            if (pendingUser !== null) result.push({ user: pendingUser, response: { answer: "" } as ChatResponse });
+            pendingUser = message.content;
+        } else {
+            result.push({ user: pendingUser ?? "", response: { answer: message.content } as ChatResponse });
+            pendingUser = null;
+        }
+    }
+    if (pendingUser !== null) result.push({ user: pendingUser, response: { answer: "" } as ChatResponse });
+    return result;
+};
+
+/**
+ * On a 409, pull the authoritative conversation from the backend and overwrite
+ * the local copy (messages + revision) and the on-screen history with it. The
+ * user's unsent input is NOT touched here (the caller restores it), and no turn
+ * is auto-resent — the reconciled revision lets the user resend successfully.
+ */
+const reconcileConversationConflict = async (
+    conversationId: string,
+    dispatch: Dispatch<any>,
+    storageService: StorageService<any, any>,
+    options: ChatOptions,
+    fetchHistory?: () => void
+): Promise<void> => {
+    const detail = await getConversation(conversationId);
+    const answers = backendMessagesToAnswers(detail.messages);
+    // Replace the local copy with the server's authoritative history + revision.
+    await storageService.update(conversationId, answers, options);
+    await storageService.setRevision(conversationId, detail.revision);
+    // Reflect the reloaded history in the UI.
+    dispatch({ type: "SET_ANSWERS", payload: answers });
+    if (fetchHistory) fetchHistory();
+};
 
 /**
  * @fileoverview Chat page helper functions for managing chat state, API requests, and user interactions.
@@ -251,6 +306,16 @@ export const makeApiRequest = async (
     // stay local-only for now, so they are not persisted server-side.
     const conversation_id = assistant_id ? undefined : (activeChatRef.current ?? uuid());
 
+    // Optimistic-concurrency precondition: send the revision the local copy of
+    // this chat is based on so the backend can reject a stale cross-device
+    // overwrite (409). Omitted for brand-new chats (no stored revision yet) so a
+    // first turn is never falsely rejected.
+    let knownRevision: number | undefined;
+    if (conversation_id) {
+        const storedChat = await storageService.get(conversation_id);
+        knownRevision = storedChat?.revision;
+    }
+
     // Build the API request object
     const request: ChatRequest = {
         history: [...history, { user: question, assistant: undefined }],
@@ -262,12 +327,23 @@ export const makeApiRequest = async (
         enabled_tools: enabled_tools && enabled_tools.length > 0 ? enabled_tools : undefined,
         assistant_id: assistant_id,
         data_sources: data_sources && data_sources.length > 0 ? data_sources : undefined,
-        conversation_id: conversation_id
+        conversation_id: conversation_id,
+        conversation_revision: knownRevision
     };
 
     // Make the API call
     const response = await chatApi(request);
     handleRedirect(response);
+
+    // Optimistic-concurrency conflict: the chat was advanced on another
+    // device/tab. Reload the authoritative server history into the store and UI
+    // (preserving the user's unsent question for resend) and signal the caller.
+    if (response.status === 409 && conversation_id) {
+        await reconcileConversationConflict(conversation_id, dispatch, storageService, options, fetchHistory);
+        isLoadingRef.current = false;
+        onLoadingChange?.(false);
+        throw new ConversationConflictError(conversation_id);
+    }
 
     // Ensure we have a response body for streaming
     if (!response.body) {
@@ -306,6 +382,11 @@ export const makeApiRequest = async (
         requestAnimationFrame(scrollToCurrentGeneration);
         setTimeout(scrollToCurrentGeneration, 120);
     });
+
+    // Captured from the final `conversation.revision` SSE event (emitted after
+    // the terminal stop chunk); persisted locally so the next turn's precondition
+    // is up to date. Trust the server value rather than incrementing locally.
+    let capturedRevision: number | undefined;
 
     // Buffer management for optimized UI updates
     let textBuffer = ""; // Accumulates regular text content
@@ -363,18 +444,33 @@ export const makeApiRequest = async (
                 if (line.startsWith("data: ")) {
                     const data = line.slice(6).trim();
 
-                    // Check for stream end marker
+                    // Stream end marker: stop accumulating but keep draining the
+                    // reader so a trailing revision event in a later read isn't
+                    // dropped. The loop ends naturally when the reader is done.
                     if (data === "[DONE]") {
-                        break;
+                        continue;
                     }
 
                     try {
                         // Parse the SSE chunk data
                         const chunk = JSON.parse(data) as ChatCompletionChunk;
+
+                        // Final optimistic-concurrency event (no `choices`). Check
+                        // this BEFORE the choice guard, and before the stop guard
+                        // below, since it is emitted after the terminal stop chunk
+                        // and may arrive in the same network read.
+                        const revisionChunk = chunk as unknown as { object?: string; conversation_revision?: number };
+                        if (revisionChunk.object === "conversation.revision") {
+                            capturedRevision = revisionChunk.conversation_revision;
+                            continue;
+                        }
+
                         const choice: ChatCompletionChunkChoice | undefined = chunk.choices?.[0];
-                        if (!choice) continue; // Check if streaming is complete
+                        if (!choice) continue;
+                        // Terminal chunk: stop UI updates but keep draining (see
+                        // [DONE] above) so the revision event is not missed.
                         if (choice.finish_reason === "stop") {
-                            break;
+                            continue;
                         }
 
                         // Handle token usage information if available
@@ -463,6 +559,12 @@ export const makeApiRequest = async (
     if (activeChatRef.current) {
         // Append to existing chat
         await storageService.appendMessage(finalMessage, activeChatRef.current, options);
+        // Persist the server's post-turn revision so the next turn sends an
+        // accurate optimistic-concurrency precondition (no-op for assistant
+        // chats, which carry no revision).
+        if (conversation_id && capturedRevision !== undefined) {
+            await storageService.setRevision(conversation_id, capturedRevision);
+        }
         if (fetchHistory) fetchHistory();
     } else {
         // Create a new chat with generated name
@@ -481,6 +583,11 @@ export const makeApiRequest = async (
                       false
                   )
                 : await storageService.create([finalMessage], options, conversation_id, chatname, false);
+
+        // Persist the server's post-turn revision on the freshly created local chat.
+        if (!assistant_id && conversation_id && capturedRevision !== undefined) {
+            await storageService.setRevision(conversation_id, capturedRevision);
+        }
 
         // Persist the generated title to the backend for normal chats (best-effort).
         if (!assistant_id && conversation_id) {

--- a/mucgpt-frontend/src/service/storage.ts
+++ b/mucgpt-frontend/src/service/storage.ts
@@ -14,6 +14,14 @@ export interface DBObject<M, C> {
     favorite?: boolean;
     messages: DBMessage<M>[];
     config: C;
+    /**
+     * Server-side optimistic-concurrency revision this chat's local history is
+     * based on. Sent back to the backend as `conversation_revision` so a stale
+     * cross-device overwrite is rejected (409). Absent = unknown -> no
+     * precondition sent (e.g. a brand-new chat's first turn). Stored as a plain
+     * optional property; no IndexedDB schema bump is needed to add it.
+     */
+    revision?: number;
 }
 
 /**
@@ -192,6 +200,26 @@ export class StorageService<M, C> {
                 setQuestion(last.user);
                 return updated;
             } else throw new Error("No object with id " + id + " found");
+        } catch (error) {
+            this.onError(error);
+        }
+    }
+
+    /**
+     * Persist the server-side optimistic-concurrency revision for a chat so the
+     * next turn sends it as the precondition. No-op if the chat is unknown.
+     */
+    async setRevision(id: string, revision: number | undefined) {
+        try {
+            if (revision === undefined) return undefined;
+            const db = await this.connectToDB();
+            const stored = await this.get(id);
+            if (stored) {
+                stored.revision = revision;
+                await db.put(this.config.objectStore_name, stored);
+                return stored;
+            }
+            return undefined;
         } catch (error) {
             this.onError(error);
         }


### PR DESCRIPTION
## Why

Every chat turn rewrites the stored conversation to the client's snapshot (`replace_messages`) before appending the assistant turn. With the same chat open on two devices/tabs, a later request could erase turns already persisted by the other client — silent **last-write-wins data loss**. (PR #1067 fixed the intra-conversation sequence race; this addresses the higher-level cross-client overwrite. Tracks #1068.)

## Approach — reject-and-reload (opt-in, backward-compatible)

A server-owned monotonic `revision` per conversation. The client sends the revision its history is based on; on a stale write the server returns **HTTP 409 before any model call** and writes nothing. The client pulls the authoritative history, reconciles, and lets the user resend. Omitting `conversation_revision` skips the check entirely → **old clients keep working, backend ships first**.

## Changes

**Backend** (`mucgpt-core-service`)
- `revision` column on `Conversation` (`server_default 0`).
- `ConflictError` + optional `expected_revision` precondition in `replace_messages` (raises before overwriting).
- Revision is bumped **only in `append_message`** (one per *persisted* turn), so a failed/aborted turn advances nothing and the client's own retry is never falsely rejected. See the tradeoff note below.
- `conversation_revision` on the chat request + non-streaming response; `revision` on conversation read/create models; documented `ConversationConflict` 409 body.
- `chat_router`: maps `ConflictError`→409 before generation; emits the new revision on the non-streaming body and via a final `conversation.revision` SSE event (after the terminal `stop` chunk, only on success — never into a closing generator on client disconnect).

**Frontend** (`mucgpt-frontend`)
- Sends the locally-stored revision (omitted for brand-new chats); captures the SSE revision event (recognized before the choice/stop guards, draining the reader to done since the event can share a network read with `stop`); persists it via `setRevision`.
- 409 → `ConversationConflictError` → pull-and-reconcile (reload server history into store + UI), restore the unsent prompt, non-blocking notice, **no auto-resend**. New `chat.conflict_*` de/en strings.
- Synced/pulled chats store the server revision.

**Docs** — dedicated section in `CHAT_PERSISTENCE.md`: contract, 409 body, streaming event, the manual `ALTER TABLE conversations ADD COLUMN revision INTEGER NOT NULL DEFAULT 0;` for existing Postgres, and the backend-first rollout.

## Scope / known residual

Bump-on-append protects the **sequential** cross-device case (the headline scenario). Two turns generating **simultaneously** are *not* caught (both `replace` before either `append`); bumping on `replace` too would catch it but would falsely 409 every failed-generation retry — protecting the sequential case while never punishing a retry is the deliberate tradeoff. Merge-on-conflict is out of scope. Documented as a known residual.

## Migration

`create_all` adds the column to **fresh** DBs only. Existing Postgres needs:
```sql
ALTER TABLE conversations ADD COLUMN revision INTEGER NOT NULL DEFAULT 0;
```

## Verification

- **Backend:** ✅ `ruff` clean, full suite green (98 passed, 5 skipped). New tests cover repo conflict/increment, router 409 (asserts **no model call**), pre-stream 409, and the revision round-trip + streaming event.
- **Frontend:** ✅ `npm run lint` clean (prettier + eslint + tsc, 0 errors). ⚠️ No frontend test runner exists in this repo (no Vitest/Jest), so roadmap step 11 is not implemented. The SSE stream-drain/capture path runs on every stream and has no automated coverage and MSW has no conversation handlers — **recommend a manual smoke on the full container stack** (one turn → confirm the next isn't falsely rejected; two tabs → confirm 409 reconcile) before marking verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)