### PR TITLE
added possibilty to scroll down to the bottom if u scrolled in an chat

### DIFF
--- a/mucgpt-frontend/src/components/ChatLayout/ChatLayout.module.css
+++ b/mucgpt-frontend/src/components/ChatLayout/ChatLayout.module.css
@@ -174,10 +174,57 @@
     justify-content: center;
     pointer-events: none;
     box-sizing: border-box;
+    transform-origin: center bottom;
 }
 
 .scrollToBottomButton {
     pointer-events: auto;
+    opacity: 0.86;
+    box-shadow: var(--shadow4);
+    transition:
+        opacity 220ms cubic-bezier(0.25, 1, 0.5, 1),
+        transform 220ms cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+.scrollToBottomButton:hover,
+.scrollToBottomButton:focus-visible {
+    opacity: 1;
+}
+
+.scrollToBottomWrapper[data-state="entered"] {
+    animation: scrollToBottomEnter 200ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.scrollToBottomWrapper[data-state="exiting"] {
+    animation: scrollToBottomExit 200ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.scrollToBottomWrapper[data-state="exiting"] .scrollToBottomButton {
+    pointer-events: none;
+}
+
+@keyframes scrollToBottomEnter {
+    from {
+        opacity: 0;
+        transform: translateY(18px) scale(0.82);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+@keyframes scrollToBottomExit {
+    from {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+
+    to {
+        opacity: 0;
+        transform: translateY(18px) scale(0.82);
+    }
 }
 
 .chatInput {
@@ -241,5 +288,19 @@
     .container[data-info-open="true"] .scrollToBottomWrapper,
     .container[data-info-open="true"] .chatInput {
         right: 0;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .scrollToBottomWrapper {
+        animation: none;
+    }
+
+    .scrollToBottomWrapper[data-state="exiting"] {
+        opacity: 0;
+    }
+
+    .scrollToBottomButton {
+        transition: opacity 0.01ms linear;
     }
 }

--- a/mucgpt-frontend/src/components/ChatLayout/ChatLayout.module.css
+++ b/mucgpt-frontend/src/components/ChatLayout/ChatLayout.module.css
@@ -164,6 +164,22 @@
     padding: 8px 24px;
 }
 
+.scrollToBottomWrapper {
+    position: fixed;
+    left: var(--appSidebarWidth, 0);
+    right: 0;
+    bottom: calc(var(--chatInputHeight, 0px) + 18px);
+    z-index: 99;
+    display: flex;
+    justify-content: center;
+    pointer-events: none;
+    box-sizing: border-box;
+}
+
+.scrollToBottomButton {
+    pointer-events: auto;
+}
+
 .chatInput {
     position: fixed;
     left: var(--appSidebarWidth, 0);
@@ -176,6 +192,7 @@
     background: transparent;
 }
 
+.container[data-info-open="true"] .scrollToBottomWrapper,
 .container[data-info-open="true"] .chatInput {
     right: var(--assistantDetailsDrawerWidth);
 }
@@ -188,6 +205,7 @@
 
     .container[data-info-open="true"] .headerBar,
     .container[data-info-open="true"] .chatRoot,
+    .container[data-info-open="true"] .scrollToBottomWrapper,
     .container[data-info-open="true"] .chatInput {
         right: var(--assistantDetailsDrawerCompactWidth);
     }
@@ -220,6 +238,7 @@
 @media (max-width: 600px) {
     .container[data-info-open="true"] .headerBar,
     .container[data-info-open="true"] .chatRoot,
+    .container[data-info-open="true"] .scrollToBottomWrapper,
     .container[data-info-open="true"] .chatInput {
         right: 0;
     }

--- a/mucgpt-frontend/src/components/ChatLayout/ChatLayout.tsx
+++ b/mucgpt-frontend/src/components/ChatLayout/ChatLayout.tsx
@@ -1,5 +1,6 @@
-import { ReactNode, useEffect, useRef, useState, type CSSProperties } from "react";
+import { ReactNode, useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
 import { Button } from "@fluentui/react-components";
+import { ArrowDown24Regular } from "@fluentui/react-icons";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -41,7 +42,9 @@ export const ChatLayout = ({
     actions
 }: Props) => {
     const chatInputRef = useRef<HTMLDivElement | null>(null);
+    const chatMessagesRef = useRef<HTMLUListElement | null>(null);
     const [chatInputHeight, setChatInputHeight] = useState(0);
+    const [showScrollToBottom, setShowScrollToBottom] = useState(false);
     const [isCompact, setIsCompact] = useState(() =>
         typeof window !== "undefined" && typeof window.matchMedia === "function" ? window.matchMedia("(max-width: 640px)").matches : false
     );
@@ -78,6 +81,58 @@ export const ChatLayout = ({
             observer.disconnect();
         };
     }, []);
+
+    const updateScrollToBottomVisibility = useCallback(() => {
+        const element = chatMessagesRef.current;
+        if (!element || showStarterPrompts) {
+            setShowScrollToBottom(false);
+            return;
+        }
+
+        const distanceFromBottom = element.scrollHeight - element.scrollTop - element.clientHeight;
+        const hasScrollableContent = element.scrollHeight > element.clientHeight + 1;
+        setShowScrollToBottom(hasScrollableContent && distanceFromBottom > 32);
+    }, [showStarterPrompts]);
+
+    useEffect(() => {
+        const element = chatMessagesRef.current;
+        if (!element || showStarterPrompts || typeof window === "undefined") {
+            setShowScrollToBottom(false);
+            return;
+        }
+
+        updateScrollToBottomVisibility();
+        const updateOnNextFrame = () => requestAnimationFrame(updateScrollToBottomVisibility);
+
+        element.addEventListener("scroll", updateScrollToBottomVisibility, { passive: true });
+        window.addEventListener("resize", updateOnNextFrame);
+
+        const resizeObserver = typeof ResizeObserver === "undefined" ? undefined : new ResizeObserver(updateOnNextFrame);
+        resizeObserver?.observe(element);
+
+        const mutationObserver = typeof MutationObserver === "undefined" ? undefined : new MutationObserver(updateOnNextFrame);
+        mutationObserver?.observe(element, { childList: true, subtree: true, characterData: true });
+
+        return () => {
+            element.removeEventListener("scroll", updateScrollToBottomVisibility);
+            window.removeEventListener("resize", updateOnNextFrame);
+            resizeObserver?.disconnect();
+            mutationObserver?.disconnect();
+        };
+    }, [answers, chatInputHeight, showStarterPrompts, updateScrollToBottomVisibility]);
+
+    const scrollToBottom = useCallback(() => {
+        const element = chatMessagesRef.current;
+        if (!element) {
+            return;
+        }
+
+        element.scrollTo({
+            top: element.scrollHeight,
+            behavior: "smooth"
+        });
+        requestAnimationFrame(updateScrollToBottomVisibility);
+    }, [updateScrollToBottomVisibility]);
 
     const containerStyle = { "--chatInputHeight": `${chatInputHeight}px` } as CSSProperties;
 
@@ -124,9 +179,22 @@ export const ChatLayout = ({
                             {starterPrompts}
                         </div>
                     ) : (
-                        <ul className={styles.allChatMessages} aria-description={messages_description}>
+                        <ul className={styles.allChatMessages} aria-description={messages_description} ref={chatMessagesRef}>
                             {answers}
                         </ul>
+                    )}
+                    {showScrollToBottom && (
+                        <div className={styles.scrollToBottomWrapper}>
+                            <Button
+                                appearance="secondary"
+                                shape="circular"
+                                size="medium"
+                                className={styles.scrollToBottomButton}
+                                icon={<ArrowDown24Regular />}
+                                onClick={scrollToBottom}
+                                aria-label="Zum Ende des Chats springen"
+                            />
+                        </div>
                     )}
                     <div className={styles.chatInput} ref={chatInputRef}>
                         {input}

--- a/mucgpt-frontend/src/components/ChatLayout/ChatLayout.tsx
+++ b/mucgpt-frontend/src/components/ChatLayout/ChatLayout.tsx
@@ -45,6 +45,7 @@ export const ChatLayout = ({
     const chatMessagesRef = useRef<HTMLUListElement | null>(null);
     const [chatInputHeight, setChatInputHeight] = useState(0);
     const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+    const [renderScrollToBottom, setRenderScrollToBottom] = useState(false);
     const [isCompact, setIsCompact] = useState(() =>
         typeof window !== "undefined" && typeof window.matchMedia === "function" ? window.matchMedia("(max-width: 640px)").matches : false
     );
@@ -120,6 +121,26 @@ export const ChatLayout = ({
             mutationObserver?.disconnect();
         };
     }, [answers, chatInputHeight, showStarterPrompts, updateScrollToBottomVisibility]);
+    useEffect(() => {
+        if (showScrollToBottom) {
+            setRenderScrollToBottom(true);
+            return;
+        }
+
+        if (!renderScrollToBottom || typeof window === "undefined" || typeof window.matchMedia !== "function") {
+            return;
+        }
+
+        if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+            setRenderScrollToBottom(false);
+        }
+    }, [renderScrollToBottom, showScrollToBottom]);
+
+    const handleScrollToBottomAnimationEnd = useCallback(() => {
+        if (!showScrollToBottom) {
+            setRenderScrollToBottom(false);
+        }
+    }, [showScrollToBottom]);
 
     const scrollToBottom = useCallback(() => {
         const element = chatMessagesRef.current;
@@ -183,8 +204,13 @@ export const ChatLayout = ({
                             {answers}
                         </ul>
                     )}
-                    {showScrollToBottom && (
-                        <div className={styles.scrollToBottomWrapper}>
+                    {renderScrollToBottom && (
+                        <div
+                            className={styles.scrollToBottomWrapper}
+                            data-state={showScrollToBottom ? "entered" : "exiting"}
+                            aria-hidden={!showScrollToBottom}
+                            onAnimationEnd={handleScrollToBottomAnimationEnd}
+                        >
                             <Button
                                 appearance="secondary"
                                 shape="circular"
@@ -192,6 +218,7 @@ export const ChatLayout = ({
                                 className={styles.scrollToBottomButton}
                                 icon={<ArrowDown24Regular />}
                                 onClick={scrollToBottom}
+                                tabIndex={showScrollToBottom ? undefined : -1}
                                 aria-label="Zum Ende des Chats springen"
                             />
                         </div>


### PR DESCRIPTION
## Summary
if the user scrolled in the chat view a "scroll down" button appears in the bottom middle part of the chat layout. the user can click this to scroll all the way down to the bottom of the chat. 

## Why
this is easier that scrolling through the whole chat history if you searched up something from a previous message.

## Validation
How was this verified?
- [ ] Automated tests
- [ ] Manual verification
- [ ] Not applicable

## UI Changes (If applicable)
*Please add screenshots or screencasts of any visual changes.*

## Change Areas
- [x] Frontend
- [ ] Core service
- [ ] Assistant service
- [ ] Migrations / DB
- [ ] Infrastructure / Docker / Compose / Keycloak
- [ ] CI / CD
- [ ] Docs

## Risks / Rollout Notes
Is there anything reviewers or operators should pay attention to?
*Examples: breaking changes, config changes, migration order, deployment considerations, rollback concerns.*

## References
Related: #
Closes: #1013


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a floating “scroll to bottom” button in chat when you’re not near the latest messages.
  * The button smoothly jumps to the newest message for easier navigation in long conversations.

* **Bug Fixes**
  * Improved responsiveness so the button stays correctly positioned across different layouts and screen sizes.
  * Updated visibility behavior to react properly to scrolling, resizing, and chat content changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->