### PR TITLE
fix(brainstorm): decode HTML entities before Freeplane .mm export

### DIFF
--- a/mucgpt-frontend/src/components/Fragments/BrainstormFragment/BrainstormFragment.tsx
+++ b/mucgpt-frontend/src/components/Fragments/BrainstormFragment/BrainstormFragment.tsx
@@ -24,6 +24,11 @@ const TEXT_ATTRIBUTE = "TEXT";
 const FOLDED_ATTRIBUTE = "FOLDED";
 const VERSION_ATTRIBUTE = "version";
 const MIN_CONTENT_LENGTH = 10;
+const htmlToText = (html: string): string => {
+    const el = document.createElement("div");
+    el.innerHTML = html;
+    return el.textContent ?? "";
+};
 
 interface Props extends BaseFragmentProps {
     markdown?: string;
@@ -57,7 +62,7 @@ export const BrainstormFragment = ({ content, markdown, showLineNumbers = true }
     // parse Nodes
     const parseNodes = useCallback((to_be_parsed: IPureNode, parent: Element, doc: Document): void => {
         const result = doc.createElement(NODE_ELEMENT);
-        result.setAttribute(TEXT_ATTRIBUTE, to_be_parsed.content);
+        result.setAttribute(TEXT_ATTRIBUTE, htmlToText(to_be_parsed.content));
 
         for (const child of to_be_parsed.children || []) {
             parseNodes(child, result, doc);
@@ -73,7 +78,7 @@ export const BrainstormFragment = ({ content, markdown, showLineNumbers = true }
             mapElem.setAttribute(VERSION_ATTRIBUTE, FREEPLANE_VERSION);
 
             const question = doc.createElement(NODE_ELEMENT);
-            question.setAttribute(TEXT_ATTRIBUTE, parsed.content);
+            question.setAttribute(TEXT_ATTRIBUTE, htmlToText(parsed.content));
             question.setAttribute(FOLDED_ATTRIBUTE, "false");
 
             for (const child of parsed.children || []) {


### PR DESCRIPTION
## Summary
What changed?
Fixes double-encoding of non-ASCII characters in the Freeplane (`.mm`) export of brainstorm mindmaps. Umlauts (ä, ö, ü, ß) were exported as literal HTML entities (e.g. `Schädlingsbekämpfung` → `Sch&#xe4;dlingsbek&#xe4;mpfung`). Adds an `htmlToText` helper in `BrainstormFragment.tsx` and applies it before writing node text into the XML, in both `parseNodes` and `parseXML`.

## Why
Why is this change needed?
markmap's `node.content` is an HTML fragment, so non-ASCII is encoded as numeric character references (`ä` → `&#xe4;`). This renders correctly in the live mindmap because markmap injects it via `innerHTML`, but the export wrote it straight into an XML attribute as plain text. `XMLSerializer` then escaped the `&` a second time (`&amp;#xe4;`), and Freeplane decoded `&amp;` back to `&`, leaving the literal entity on screen. Decoding the HTML to plain text before the attribute write breaks the double-encoding. This affects nearly all German-language maps.

## Validation
How was this verified?
- [ ] Automated tests
- [x] Manual verification
- [ ] Not applicable

## UI Changes (If applicable)
*Please add screenshots or screencasts of any visual changes.*
No in-app UI changes; the live mindmap already rendered correctly. Change affects only the downloaded `.mm` file.

## Change Areas
- [x] Frontend
- [ ] Core service
- [ ] Assistant service
- [ ] Migrations / DB
- [ ] Infrastructure / Docker / Compose / Keycloak
- [ ] CI / CD
- [ ] Docs

## Risks / Rollout Notes
Is there anything reviewers or operators should pay attention to?
*Examples: breaking changes, config changes, migration order, deployment considerations, rollback concerns.*

Low risk, single-file frontend change, no config or breaking changes. `htmlToText` also strips any inline markup markmap may emit (e.g. `<strong>`), so node labels export as plain text — desired for `.mm`, but worth a reviewer's eye if bold/formatted node text was ever intended to survive export. It relies on `document` (browser DOM), consistent with the surrounding component. No migration or rollback concerns.

## References
Closes: #1074 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved export formatting by converting rich text content to plain text before generating the XML output.
  * Reduced the chance of invalid or messy text appearing in exported mind maps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->