### PR TITLE
Refine chat draft and startup behavior

### DIFF
--- a/mucgpt-frontend/src/components/QuestionInput/QuestionInput.tsx
+++ b/mucgpt-frontend/src/components/QuestionInput/QuestionInput.tsx
@@ -68,16 +68,13 @@ export const QuestionInput = ({
     const [isExpandedInput, setIsExpandedInput] = useState(false);
     const dragCounterRef = useRef(0);
     const isDraftHydratedRef = useRef(false);
-    const skipNextEmptyPersistRef = useRef(false);
-    const pendingSendRef = useRef(false);
-    const wasDisabledRef = useRef(disabled);
+    const isPageUnloadingRef = useRef(false);
     const setQuestionRef = useRef(setQuestion);
     const recordingBaseRef = useRef("");
     const { isModelReady: transcriptionReady, status: transcriptionStatus } = useTranscription();
     const isTranscriptionActive = transcriptionStatus === "recording" || transcriptionStatus === "transcribing";
 
     const draftStorageKey = draftCacheKey ? `question-input-draft:${draftCacheKey}` : undefined;
-    const pendingStorageKey = draftCacheKey ? `question-input-pending:${draftCacheKey}` : undefined;
 
     const uploadedData = externalUploadedData ?? internalUploadedData;
     const activeDocumentCount = uploadedData.filter(data => data.isActive !== false).length;
@@ -104,79 +101,65 @@ export const QuestionInput = ({
     }, [setQuestion]);
 
     useEffect(() => {
-        isDraftHydratedRef.current = false;
-        skipNextEmptyPersistRef.current = false;
-        pendingSendRef.current = false;
+        const handleBeforeUnload = () => {
+            isPageUnloadingRef.current = true;
+        };
 
-        if (!draftStorageKey || !pendingStorageKey || question.trim().length > 0) {
+        window.addEventListener("beforeunload", handleBeforeUnload);
+
+        return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+    }, []);
+
+    useEffect(() => {
+        return () => {
+            if (!draftStorageKey || isPageUnloadingRef.current) {
+                return;
+            }
+
+            try {
+                sessionStorage.removeItem(draftStorageKey);
+            } catch {
+                // Ignore sessionStorage errors while cleaning up route-local drafts.
+            }
+        };
+    }, [draftStorageKey]);
+
+    useEffect(() => {
+        isDraftHydratedRef.current = false;
+
+        if (!draftStorageKey || question.trim().length > 0) {
             isDraftHydratedRef.current = true;
             return;
         }
 
         try {
-            const draftQuestion = localStorage.getItem(draftStorageKey);
-            const pendingQuestion = localStorage.getItem(pendingStorageKey);
-            const restoredQuestion = draftQuestion || pendingQuestion;
+            const draftQuestion = sessionStorage.getItem(draftStorageKey);
 
-            if (restoredQuestion) {
-                setQuestionRef.current(restoredQuestion);
+            if (draftQuestion) {
+                setQuestionRef.current(draftQuestion);
             }
         } catch {
-            // Ignore localStorage errors and continue without draft restore.
+            // Ignore sessionStorage errors and continue without draft restore.
         } finally {
             isDraftHydratedRef.current = true;
         }
-    }, [draftStorageKey, pendingStorageKey]);
+    }, [draftStorageKey]);
 
     useEffect(() => {
-        if (!draftStorageKey || !pendingStorageKey || !isDraftHydratedRef.current) {
-            return;
-        }
-
-        const trimmedQuestion = question.trim();
-        if (skipNextEmptyPersistRef.current && trimmedQuestion.length === 0) {
-            skipNextEmptyPersistRef.current = false;
+        if (!draftStorageKey || !isDraftHydratedRef.current) {
             return;
         }
 
         try {
-            if (trimmedQuestion.length > 0) {
-                localStorage.setItem(draftStorageKey, question);
-                const pendingQuestion = localStorage.getItem(pendingStorageKey);
-                if (pendingQuestion && pendingQuestion !== question) {
-                    localStorage.removeItem(pendingStorageKey);
-                    pendingSendRef.current = false;
-                }
+            if (question.trim().length > 0) {
+                sessionStorage.setItem(draftStorageKey, question);
             } else {
-                localStorage.removeItem(draftStorageKey);
+                sessionStorage.removeItem(draftStorageKey);
             }
         } catch {
-            // Ignore localStorage errors and continue without draft persistence.
+            // Ignore sessionStorage errors and continue without draft persistence.
         }
-    }, [draftStorageKey, pendingStorageKey, question]);
-
-    useEffect(() => {
-        if (!draftStorageKey || !pendingStorageKey) {
-            wasDisabledRef.current = disabled;
-            return;
-        }
-
-        const completedPendingRequest = pendingSendRef.current && wasDisabledRef.current && !disabled;
-        if (completedPendingRequest) {
-            try {
-                localStorage.removeItem(pendingStorageKey);
-                if (question.trim().length === 0) {
-                    localStorage.removeItem(draftStorageKey);
-                }
-            } catch {
-                // Ignore localStorage errors and keep app behavior unchanged.
-            } finally {
-                pendingSendRef.current = false;
-            }
-        }
-
-        wasDisabledRef.current = disabled;
-    }, [disabled, draftStorageKey, pendingStorageKey, question]);
+    }, [draftStorageKey, question]);
 
     const hasFileData = useCallback((dataTransfer?: DataTransfer | null) => {
         if (!dataTransfer?.types) {
@@ -251,15 +234,6 @@ export const QuestionInput = ({
             return;
         }
 
-        if (pendingStorageKey) {
-            try {
-                localStorage.setItem(pendingStorageKey, question);
-                pendingSendRef.current = true;
-            } catch {
-                // Ignore localStorage errors and continue sending.
-            }
-        }
-
         const activeData = uploadedData.filter(data => data.isActive !== false);
         onSend(question, activeData);
 
@@ -267,8 +241,10 @@ export const QuestionInput = ({
             return;
         }
 
-        if (draftStorageKey) {
-            skipNextEmptyPersistRef.current = true;
+        try {
+            if (draftStorageKey) sessionStorage.removeItem(draftStorageKey);
+        } catch {
+            // Ignore sessionStorage errors and keep the UI state unchanged.
         }
 
         setQuestion("");
@@ -277,19 +253,7 @@ export const QuestionInput = ({
             setUploadedData([]);
             onDataChange?.([]);
         }
-    }, [
-        clearOnSend,
-        disabled,
-        draftStorageKey,
-        externalUploadedData,
-        onDataChange,
-        onSend,
-        pendingStorageKey,
-        question,
-        setQuestion,
-        setUploadedData,
-        uploadedData
-    ]);
+    }, [clearOnSend, disabled, draftStorageKey, externalUploadedData, onDataChange, onSend, question, setQuestion, setUploadedData, uploadedData]);
 
     const onEnterPress = useCallback(
         (event: React.KeyboardEvent<Element>) => {

--- a/mucgpt-frontend/src/components/QuestionInput/QuestionInput.tsx
+++ b/mucgpt-frontend/src/components/QuestionInput/QuestionInput.tsx
@@ -30,6 +30,7 @@ interface Props {
     uploadedData?: UploadedData[];
     setUploadedData?: Dispatch<SetStateAction<UploadedData[]>>;
     draftCacheKey?: string;
+    skipDraftRestore?: boolean;
     onTranscription?: (text: string) => void;
 }
 
@@ -50,6 +51,7 @@ export const QuestionInput = ({
     uploadedData: externalUploadedData,
     setUploadedData: setExternalUploadedData,
     draftCacheKey,
+    skipDraftRestore = false,
     onTranscription
 }: Props) => {
     const { t } = useTranslation();
@@ -132,6 +134,17 @@ export const QuestionInput = ({
             return;
         }
 
+        if (skipDraftRestore) {
+            try {
+                sessionStorage.removeItem(draftStorageKey);
+            } catch {
+                // Ignore sessionStorage errors while clearing skipped drafts.
+            } finally {
+                isDraftHydratedRef.current = true;
+            }
+            return;
+        }
+
         try {
             const draftQuestion = sessionStorage.getItem(draftStorageKey);
 
@@ -143,10 +156,10 @@ export const QuestionInput = ({
         } finally {
             isDraftHydratedRef.current = true;
         }
-    }, [draftStorageKey]);
+    }, [draftStorageKey, skipDraftRestore]);
 
     useEffect(() => {
-        if (!draftStorageKey || !isDraftHydratedRef.current) {
+        if (!draftStorageKey || skipDraftRestore || !isDraftHydratedRef.current) {
             return;
         }
 
@@ -159,7 +172,7 @@ export const QuestionInput = ({
         } catch {
             // Ignore sessionStorage errors and continue without draft persistence.
         }
-    }, [draftStorageKey, question]);
+    }, [draftStorageKey, question, skipDraftRestore]);
 
     const hasFileData = useCallback((dataTransfer?: DataTransfer | null) => {
         if (!dataTransfer?.types) {

--- a/mucgpt-frontend/src/pages/chat/Chat.tsx
+++ b/mucgpt-frontend/src/pages/chat/Chat.tsx
@@ -196,6 +196,7 @@ const Chat = () => {
                     dispatch({ type: "SET_CREATIVITY", payload: chat.config.creativity });
                     dispatch({ type: "SET_SYSTEM_PROMPT", payload: chat.config.system });
                     dispatch({ type: "SET_ACTIVE_CHAT", payload: id });
+                    setQuestion("");
                     lastQuestionRef.current = chat.messages.length > 0 ? chat.messages[chat.messages.length - 1].user : "";
 
                     // Scroll to bottom after a short delay to ensure DOM is updated
@@ -214,22 +215,6 @@ const Chat = () => {
         },
         [storageService, scrollToBottom]
     );
-
-    const loadNewestChat = useCallback(async () => {
-        const existingData = await storageService.getNewestChat();
-        if (!existingData) {
-            lastQuestionRef.current = "";
-            dispatch({ type: "SET_ACTIVE_CHAT", payload: undefined });
-            dispatch({ type: "CLEAR_ANSWERS" });
-            return;
-        }
-
-        dispatch({ type: "SET_ANSWERS", payload: existingData.messages });
-        dispatch({ type: "SET_CREATIVITY", payload: existingData.config.creativity });
-        dispatch({ type: "SET_SYSTEM_PROMPT", payload: existingData.config.system });
-        dispatch({ type: "SET_ACTIVE_CHAT", payload: existingData.id });
-        lastQuestionRef.current = existingData.messages.length > 0 ? existingData.messages[existingData.messages.length - 1].user : "";
-    }, [storageService]);
 
     // Clear chat state
     const clearChat = useCallback(() => {
@@ -576,7 +561,7 @@ const Chat = () => {
                 .then(async loaded => {
                     if (!loaded) {
                         clearNavigationQueryParams();
-                        await loadNewestChat();
+                        clearChat();
                     }
                     return fetchHistory();
                 })
@@ -606,7 +591,7 @@ const Chat = () => {
                 });
         } else {
             // Normal initialization ohne URL-Parameter
-            loadNewestChat()
+            Promise.resolve(clearChat())
                 .then(() => {
                     setIsInitialized(true);
                     return fetchHistory();
@@ -615,7 +600,7 @@ const Chat = () => {
                     isLoadingRef.current = false;
                 });
         }
-    }, [clearChat, clearNavigationQueryParams, fetchHistory, getNavigationParams, loadChat, loadNewestChat]);
+    }, [clearChat, clearNavigationQueryParams, fetchHistory, getNavigationParams, loadChat]);
 
     useEffect(() => {
         if (!isInitialized) {
@@ -628,7 +613,7 @@ const Chat = () => {
             void loadChat(chatIdFromUrl).then(async loaded => {
                 if (!loaded) {
                     clearNavigationQueryParams();
-                    await loadNewestChat();
+                    clearChat();
                     await fetchHistory();
                 }
             });
@@ -648,7 +633,7 @@ const Chat = () => {
         setPendingQuestion(null);
         void startFreshChat();
         clearNavigationQueryParams();
-    }, [clearNavigationQueryParams, fetchHistory, getNavigationParams, isCurrentChatEmpty, isInitialized, loadChat, loadNewestChat, startFreshChat]);
+    }, [clearNavigationQueryParams, fetchHistory, getNavigationParams, isCurrentChatEmpty, isInitialized, loadChat, startFreshChat]);
 
     useEffect(() => {
         if (!isInitialized || !pendingQuestion || tools === undefined) {

--- a/mucgpt-frontend/src/pages/chat/Chat.tsx
+++ b/mucgpt-frontend/src/pages/chat/Chat.tsx
@@ -169,6 +169,10 @@ const Chat = () => {
         [activeChatRef.current, storageService]
     );
 
+    const resetInputState = useCallback(() => {
+        setQuestion("");
+        setUploadedData([]);
+    }, []);
     // Fetch chat history
     const fetchHistory = useCallback(async () => {
         try {
@@ -196,7 +200,7 @@ const Chat = () => {
                     dispatch({ type: "SET_CREATIVITY", payload: chat.config.creativity });
                     dispatch({ type: "SET_SYSTEM_PROMPT", payload: chat.config.system });
                     dispatch({ type: "SET_ACTIVE_CHAT", payload: id });
-                    setQuestion("");
+                    resetInputState();
                     lastQuestionRef.current = chat.messages.length > 0 ? chat.messages[chat.messages.length - 1].user : "";
 
                     // Scroll to bottom after a short delay to ensure DOM is updated
@@ -213,7 +217,7 @@ const Chat = () => {
                 return false;
             }
         },
-        [storageService, scrollToBottom]
+        [storageService, scrollToBottom, resetInputState]
     );
 
     // Clear chat state
@@ -231,11 +235,12 @@ const Chat = () => {
                 activeChatId: active_chat,
                 resetActiveChat: (chatId: string) => {
                     if (chatId === activeChatRef.current) {
+                        resetInputState();
                         clearChat();
                     }
                 }
             }),
-            [active_chat, clearChat]
+            [active_chat, clearChat, resetInputState]
         )
     );
 
@@ -438,10 +443,9 @@ const Chat = () => {
 
     const startFreshChat = useCallback(async () => {
         scheduledQuestionRef.current = null;
-        setQuestion("");
-        setUploadedData([]);
+        resetInputState();
         clearChat();
-    }, [clearChat]);
+    }, [clearChat, resetInputState]);
 
     const isCurrentChatEmpty = useMemo(
         () => answers.length === 0 && question.trim() === "" && uploadedData.length === 0 && pendingQuestion === null,
@@ -561,6 +565,7 @@ const Chat = () => {
                 .then(async loaded => {
                     if (!loaded) {
                         clearNavigationQueryParams();
+                        resetInputState();
                         clearChat();
                     }
                     return fetchHistory();
@@ -600,7 +605,7 @@ const Chat = () => {
                     isLoadingRef.current = false;
                 });
         }
-    }, [clearChat, clearNavigationQueryParams, fetchHistory, getNavigationParams, loadChat]);
+    }, [clearChat, clearNavigationQueryParams, fetchHistory, getNavigationParams, loadChat, resetInputState]);
 
     useEffect(() => {
         if (!isInitialized) {
@@ -613,6 +618,7 @@ const Chat = () => {
             void loadChat(chatIdFromUrl).then(async loaded => {
                 if (!loaded) {
                     clearNavigationQueryParams();
+                    resetInputState();
                     clearChat();
                     await fetchHistory();
                 }
@@ -633,7 +639,7 @@ const Chat = () => {
         setPendingQuestion(null);
         void startFreshChat();
         clearNavigationQueryParams();
-    }, [clearNavigationQueryParams, fetchHistory, getNavigationParams, isCurrentChatEmpty, isInitialized, loadChat, startFreshChat]);
+    }, [clearNavigationQueryParams, fetchHistory, getNavigationParams, isCurrentChatEmpty, isInitialized, loadChat, resetInputState, startFreshChat]);
 
     useEffect(() => {
         if (!isInitialized || !pendingQuestion || tools === undefined) {
@@ -756,12 +762,15 @@ const Chat = () => {
         [onStarterPromptClicked]
     );
 
-    const inputComponent = useMemo(
-        () => (
+    const inputComponent = useMemo(() => {
+        const { questionFromUrl, newChatRequested } = getNavigationParams();
+
+        return (
             <QuestionInput
                 clearOnSend
                 disabled={isLoading || error !== undefined}
                 draftCacheKey="chat-main"
+                skipDraftRestore={!!questionFromUrl || newChatRequested}
                 onSend={(question, datas) => {
                     const dataSources = uploadedDataToDataSources(datas);
                     callApi(question, systemPrompt, dataSources.length > 0 ? dataSources : undefined);
@@ -775,9 +784,8 @@ const Chat = () => {
                 setUploadedData={setUploadedData}
                 onTranscription={text => setQuestion(text)}
             />
-        ),
-        [callApi, systemPrompt, question, t, isLoading, selectedTools, tools, uploadedData, uploadedDataToDataSources]
-    );
+        );
+    }, [callApi, systemPrompt, question, t, isLoading, selectedTools, tools, uploadedData, uploadedDataToDataSources, getNavigationParams]);
 
     const layout = useMemo(
         () => (


### PR DESCRIPTION
## Summary
What changed?

- Store unsent question drafts in `sessionStorage` instead of `localStorage`.
- Keep drafts only for browser reloads, and clear them on normal in-app navigation.
- Remove pending-send draft recovery logic from `QuestionInput`.
- Start the chat page with an empty conversation instead of auto-loading the newest chat.
- Clear the current input when opening a saved chat from history.

## Why
Why is this change needed?

Drafts should protect users from accidental reloads, but should not persist across unrelated app navigation or browser sessions. The previous behavior could make old input reappear later in surprising contexts, especially between the homepage input and chat/history views.

Starting the chat page empty also avoids implicitly reopening the latest conversation when users navigate to chat without selecting a specific history item.

## Validation
How was this verified?
- [ ] Automated tests
- [ ] Manual verification
- [ ] Not applicable

## UI Changes (If applicable)
*Please add screenshots or screencasts of any visual changes.*

## Change Areas
- [x] Frontend
- [ ] Core service
- [ ] Assistant service
- [ ] Migrations / DB
- [ ] Infrastructure / Docker / Compose / Keycloak
- [ ] CI / CD
- [ ] Docs

## Risks / Rollout Notes
Is there anything reviewers or operators should pay attention to?
*Examples: breaking changes, config changes, migration order, deployment considerations, rollback concerns.*

## References
Related: #
Closes: #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Draft questions now persist more reliably during normal use and are cleared when sent, reducing unexpected loss or reappearing text.
  * Closing or reloading the page no longer removes an in-progress draft unexpectedly.
  * Opening an existing chat now clears the input field correctly, preventing old text from showing up in the wrong conversation.
  * Chat recovery now falls back more consistently when a saved chat can’t be restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->