### PR TITLE
fix(mcp): stop caching MCP tool credentials in Redis

### DIFF
--- a/mucgpt-core-service/app/agent/tools/mcp.py
+++ b/mucgpt-core-service/app/agent/tools/mcp.py
@@ -109,6 +109,12 @@ class McpLoader:
 
                 con = McpLoader._build_connection(source_id, source_cfg, user_info)
                 if con is None:
+                    # Unsupported transport: this source can never yield tools, so
+                    # count it as failed. Otherwise an all-unsupported config would
+                    # leave raw_by_source and failed_sources both empty, which takes
+                    # the "healthy load" branch below and caches an empty tool set
+                    # for the full TTL instead of the short-TTL failure path.
+                    failed_sources.add(source_id)
                     continue
 
                 try:

--- a/mucgpt-core-service/app/agent/tools/mcp.py
+++ b/mucgpt-core-service/app/agent/tools/mcp.py
@@ -42,6 +42,21 @@ class McpLoader:
         Only secret-free raw tool metadata (name/description/inputSchema) is ever cached in Redis.
         Auth/headers are rebuilt fresh from current config + user_info on every call, cache hit or
         not, so no credential ever gets persisted to the cache.
+
+        Why this matters (this used to be a real vulnerability, not just a style choice):
+        a LangChain `BaseTool` object is not inert metadata. Each tool's invocation closure
+        holds a live reference to its full MCP connection dict — including any decrypted
+        secret header values and a per-user bearer-auth object. Earlier versions of this
+        loader cached those whole `BaseTool` objects via `RedisCache`, which serializes with
+        `cloudpickle` (see core/cache.py). Unlike `json`, `cloudpickle` happily serializes
+        arbitrary Python object graphs, closures and all — so credentials were being written
+        into Redis without a single line of this file ever mentioning `secret_value`. The
+        result: anyone with read access to that Redis instance could recover live, working
+        credentials for up to `CACHE_TTL` (12h by default) after they were cached, well past
+        the lifetime of the request that produced them. That's why every code path below
+        keeps only secret-free raw `MCPTool` metadata in the cached payload, and always
+        rebuilds the live connection/auth via `_build_connection` fresh from current config
+        and `user_info` — never from anything that was ever persisted to Redis.
         """
         sources = McpLoader._mcp_settings.SOURCES
         McpLoader._logger.info(
@@ -59,7 +74,9 @@ class McpLoader:
 
         # Decide effective force-reload behavior
         effective_force = (
-            McpLoader._mcp_settings.FORCE_RELOAD if force_reload is None else force_reload
+            McpLoader._mcp_settings.FORCE_RELOAD
+            if force_reload is None
+            else force_reload
         )
 
         async def cached_or_none() -> list[BaseTool] | None:
@@ -75,7 +92,9 @@ class McpLoader:
             if cached is not None:
                 return cached
         else:
-            McpLoader._logger.info("Force-reload enabled: bypassing MCP tools cache read")
+            McpLoader._logger.info(
+                "Force-reload enabled: bypassing MCP tools cache read"
+            )
 
         # Helper to discover raw (secret-free) tool metadata from all sources
         async def fetch_all_tools() -> tuple[dict[str, list[MCPTool]], set[str]]:

--- a/mucgpt-core-service/app/agent/tools/mcp.py
+++ b/mucgpt-core-service/app/agent/tools/mcp.py
@@ -24,7 +24,15 @@ _MAX_LIST_TOOLS_ITERATIONS = 1000
 
 
 class McpLoader:
-    _CACHE_PREFIX = "mcp_tools"
+    # "_raw" marks the cache schema: only secret-free raw MCPTool metadata (see
+    # _wrap_raw_tools' docstring). Older deployments cached a different shape
+    # (pickled live BaseTool objects) under the plain "mcp_tools" prefix. Keeping
+    # the prefix distinct means any pre-upgrade entries still sitting in Redis are
+    # simply never read - a clean cache miss - instead of reaching _wrap_raw_tools
+    # with the wrong shape and crashing on the first read after a deploy. If this
+    # cache's stored shape ever changes again, bump this suffix again rather than
+    # reusing a prefix that may already hold a different payload shape.
+    _CACHE_PREFIX = "mcp_tools_raw"
     _logger = getLogger(name="mucgpt-core-mcp-loader")
     _mcp_settings = get_mcp_settings()
 

--- a/mucgpt-core-service/app/agent/tools/mcp.py
+++ b/mucgpt-core-service/app/agent/tools/mcp.py
@@ -2,8 +2,14 @@ import asyncio
 
 from httpx import Auth, Request
 from langchain_core.tools import BaseTool
-from langchain_mcp_adapters.client import MultiServerMCPClient
-from langchain_mcp_adapters.sessions import SSEConnection, StreamableHttpConnection
+from langchain_mcp_adapters.sessions import (
+    SSEConnection,
+    StreamableHttpConnection,
+    create_session,
+)
+from langchain_mcp_adapters.tools import convert_mcp_tool_to_langchain_tool
+from mcp import ClientSession
+from mcp.types import Tool as MCPTool
 from redis.asyncio import Redis
 from redis.exceptions import LockError
 
@@ -11,6 +17,10 @@ from config.settings import MCPSourceConfig, MCPTransport, get_mcp_settings
 from core.auth_models import AuthenticationResult
 from core.cache import RedisCache
 from core.logtools import getLogger
+
+# Mirrors langchain_mcp_adapters.tools.MAX_ITERATIONS: a safety bound on paginated
+# tools/list calls, not a real-world limit any MCP server is expected to hit.
+_MAX_LIST_TOOLS_ITERATIONS = 1000
 
 
 class McpLoader:
@@ -28,6 +38,10 @@ class McpLoader:
         - Avoid caching partial results for full TTL after per-source failures.
         - Avoid returning [] during cache warm-up; wait briefly and, if needed, do an uncached load.
         - Support configurable forced reload (bypass cache reads) via config or per-call override.
+
+        Only secret-free raw tool metadata (name/description/inputSchema) is ever cached in Redis.
+        Auth/headers are rebuilt fresh from current config + user_info on every call, cache hit or
+        not, so no credential ever gets persisted to the cache.
         """
         sources = McpLoader._mcp_settings.SOURCES
         McpLoader._logger.info(
@@ -48,17 +62,25 @@ class McpLoader:
             McpLoader._mcp_settings.FORCE_RELOAD if force_reload is None else force_reload
         )
 
+        async def cached_or_none() -> list[BaseTool] | None:
+            raw_dump: dict[str, list[MCPTool]] | None = await RedisCache.get_object(
+                cache_key
+            )
+            if raw_dump is None:
+                return None
+            return McpLoader._wrap_raw_tools(raw_dump, user_info, sources)
+
         if not effective_force:
-            tools_dump: list[BaseTool] | None = await RedisCache.get_object(cache_key)
-            if tools_dump is not None:
-                return tools_dump
+            cached = await cached_or_none()
+            if cached is not None:
+                return cached
         else:
             McpLoader._logger.info("Force-reload enabled: bypassing MCP tools cache read")
 
-
-        # Helper to build connections and fetch tools from all sources
-        async def fetch_all_tools() -> tuple[list[BaseTool], set[str]]:
-            mcp_connections = {}
+        # Helper to discover raw (secret-free) tool metadata from all sources
+        async def fetch_all_tools() -> tuple[dict[str, list[MCPTool]], set[str]]:
+            raw_by_source: dict[str, list[MCPTool]] = {}
+            failed_sources: set[str] = set()
 
             for source_id, source_cfg in sources.items():
                 McpLoader._logger.info(
@@ -66,114 +88,19 @@ class McpLoader:
                     f"with transport '{source_cfg.transport}' and url '{source_cfg.url}'"
                 )
 
-                if source_cfg.transport is MCPTransport.SSE:
-                    con = SSEConnection(
-                        transport=MCPTransport.SSE.value,
-                        url=source_cfg.url,
-                    )
-                elif source_cfg.transport is MCPTransport.STREAMABLE_HTTP:
-                    con = StreamableHttpConnection(
-                        transport=MCPTransport.STREAMABLE_HTTP.value,
-                        url=source_cfg.url,
-                    )
-                else:
-                    McpLoader._logger.error(
-                        f"Unsupported transport protocol {source_cfg.transport} "
-                        f"for MCP source {source_id}"
-                    )
+                con = McpLoader._build_connection(source_id, source_cfg, user_info)
+                if con is None:
                     continue
 
-                con["headers"] = {}
-
-                if source_cfg.headers:
-                    con["headers"].update(
-                        {
-                            header_name: header_value.get_secret_value()
-                            for header_name, header_value in source_cfg.headers.items()
-                            if header_name.lower() != "authorization"
-                        }
-                    )
-
-                if source_cfg.forward_token:
-                    auth_override = (
-                        source_cfg.forward_auth_override.get_secret_value()
-                        if source_cfg.forward_auth_override
-                        else None
-                    )
-
-                    con["auth"] = McpBearerAuthProvider(
-                        uid=user_info.user_id,
-                        token=user_info.token,
-                        auth_override=auth_override,
-                    )
-
-                header_names = sorted(con["headers"].keys())
-                McpLoader._logger.info(
-                    f"Header names configured for source '{source_id}': {header_names}"
-                )
-
-                mcp_connections[source_id] = con
-
-            McpLoader._logger.info("Loading MCP tools")
-            mcp_client = MultiServerMCPClient(connections=mcp_connections)
-
-            tools: list[BaseTool] = []
-            failed_sources: set[str] = set()
-
-            for source_id in mcp_connections.keys():
                 try:
-                    source_tools = await mcp_client.get_tools(server_name=source_id)
+                    async with create_session(con) as session:
+                        await session.initialize()
+                        raw_tools = await McpLoader._list_all_tools_for_session(session)
 
-                    source_config = sources[source_id]
-
-                    # Attempt to load detailed tool descriptions for this mcp-source
-                    # this is optional and only used to enrich the tool metadata with a more detailed description, if available
-                    # The idea is that by customizing the mcp tool description files,
-                    # we can provide better, e.g. usecase specific, descriptions for the tools
-                    # We found that the descriptions provided by the MCP sources themselves are often not sufficient for good performance,
-                    # so this is a way to enrich them
-                    config_descriptions = source_config.descriptions or []
-                    for source_tool in source_tools:
-                        custom_desc_entry = next(
-                            (
-                                d
-                                for d in config_descriptions
-                                if d.name == source_tool.name
-                            ),
-                            None,
-                        )
-                        custom_desc = (
-                            custom_desc_entry.description if custom_desc_entry else None
-                        )
-
-                        existing_metadata = dict(
-                            getattr(source_tool, "metadata", {}) or {}
-                        )
-                        old_description = existing_metadata.pop("description", None)
-
-                        metadata = {
-                            **existing_metadata,
-                            "mcp_source": source_id,
-                            "mcp_group": McpLoader._resolve_group(
-                                tool_name=source_tool.name,
-                                source_config=source_config,
-                            ),
-                        }
-
-                        if custom_desc:
-                            metadata["description"] = custom_desc
-                            source_tool.description = custom_desc
-                        elif old_description:
-                            metadata["description"] = old_description
-                            source_tool.description = old_description
-
-                        source_tool.metadata = metadata
-
+                    raw_by_source[source_id] = raw_tools
                     McpLoader._logger.info(
-                        f"Retrieved MCP tools from '{source_id}': {len(source_tools)}"
+                        f"Retrieved MCP tools from '{source_id}': {len(raw_tools)}"
                     )
-                    tools.extend(source_tools)
-
                 except Exception as e:
                     McpLoader._logger.error(
                         f"Exception while fetching MCP tools from '{source_id}'",
@@ -181,7 +108,7 @@ class McpLoader:
                     )
                     failed_sources.add(source_id)
 
-            return tools, failed_sources
+            return raw_by_source, failed_sources
 
         redis: Redis = await RedisCache.get_redis()
         lock_name = f"{cache_key}:lock"
@@ -191,18 +118,18 @@ class McpLoader:
             async with lock:
                 McpLoader._logger.info("Acquired MCP tools lock")
 
-                                # Re-check cache after acquiring the lock unless forced reload
+                # Re-check cache after acquiring the lock unless forced reload
                 if not effective_force:
-                    tools_dump = await RedisCache.get_object(cache_key)
-                    if tools_dump is not None:
-                        return tools_dump
+                    cached = await cached_or_none()
+                    if cached is not None:
+                        return cached
 
-
-                tools, failed_sources = await fetch_all_tools()
+                raw_by_source, failed_sources = await fetch_all_tools()
+                total_tools = sum(len(v) for v in raw_by_source.values())
 
                 if failed_sources:
                     # Do not cache partial/empty results for the full TTL.
-                    if tools:
+                    if total_tools > 0:
                         short_ttl = 60  # Short TTL for partial success
                         McpLoader._logger.warning(
                             "Partial MCP tool load: failed sources=%s, caching partial set for %ss",
@@ -211,7 +138,7 @@ class McpLoader:
                         )
                         await RedisCache.set_object(
                             key=cache_key,
-                            obj=tools,
+                            obj=raw_by_source,
                             ttl=short_ttl,
                         )
                     else:
@@ -219,15 +146,15 @@ class McpLoader:
                             "All MCP sources failed (%s); returning empty set without caching",
                             sorted(list(failed_sources)),
                         )
-                    return tools
+                    return McpLoader._wrap_raw_tools(raw_by_source, user_info, sources)
 
                 # Healthy load: cache with full TTL
                 await RedisCache.set_object(
                     key=cache_key,
-                    obj=tools,
+                    obj=raw_by_source,
                     ttl=McpLoader._mcp_settings.CACHE_TTL,
                 )
-                return tools
+                return McpLoader._wrap_raw_tools(raw_by_source, user_info, sources)
 
         except LockError:
             # Another worker is warming the cache. Wait for a bounded deadline
@@ -237,24 +164,201 @@ class McpLoader:
             )
             for _ in range(15):  # ~3s total @ 200ms
                 if not effective_force:
-                    tools_dump = await RedisCache.get_object(cache_key)
-                    if tools_dump is not None:
-                        return tools_dump
+                    cached = await cached_or_none()
+                    if cached is not None:
+                        return cached
                 await asyncio.sleep(0.2)
-
 
             # If still not available, perform an uncached load to avoid hiding tools.
             McpLoader._logger.warning(
                 "Cache not ready after wait; performing uncached MCP tool load"
             )
-            tools, _failed = await fetch_all_tools()
-            return tools
+            raw_by_source, _failed = await fetch_all_tools()
+            return McpLoader._wrap_raw_tools(raw_by_source, user_info, sources)
         except Exception as e:
             McpLoader._logger.error(
                 "Failed to acquire/use MCP tools lock",
                 exc_info=e,
             )
             raise
+
+    @staticmethod
+    async def _list_all_tools_for_session(session: ClientSession) -> list[MCPTool]:
+        """List all available tools from an MCP session, following pagination.
+
+        Reimplemented locally (rather than importing langchain_mcp_adapters.tools's
+        underscore-private equivalent) since langchain-mcp-adapters is pinned with an
+        unbounded upper version (`>=0.2.2`) and private symbols aren't a stable contract.
+        """
+        current_cursor: str | None = None
+        all_tools: list[MCPTool] = []
+        iterations = 0
+
+        while True:
+            iterations += 1
+            if iterations > _MAX_LIST_TOOLS_ITERATIONS:
+                raise RuntimeError(
+                    f"Reached max of {_MAX_LIST_TOOLS_ITERATIONS} iterations while listing tools."
+                )
+
+            list_tools_page_result = await session.list_tools(cursor=current_cursor)
+
+            if list_tools_page_result.tools:
+                all_tools.extend(list_tools_page_result.tools)
+
+            if not list_tools_page_result.nextCursor:
+                break
+
+            current_cursor = list_tools_page_result.nextCursor
+
+        return all_tools
+
+    @staticmethod
+    def _build_connection(
+        source_id: str,
+        source_cfg: MCPSourceConfig,
+        user_info: AuthenticationResult,
+    ) -> SSEConnection | StreamableHttpConnection | None:
+        """Build a connection dict with live headers/auth for a single MCP source.
+
+        This is the only place credentials are ever materialized. It must be called
+        fresh for every use (discovery and tool invocation alike) and its result must
+        never be cached, since it carries plaintext secrets (static headers, forwarded
+        bearer tokens, auth overrides).
+        """
+        if source_cfg.transport is MCPTransport.SSE:
+            con = SSEConnection(
+                transport=MCPTransport.SSE.value,
+                url=source_cfg.url,
+            )
+        elif source_cfg.transport is MCPTransport.STREAMABLE_HTTP:
+            con = StreamableHttpConnection(
+                transport=MCPTransport.STREAMABLE_HTTP.value,
+                url=source_cfg.url,
+            )
+        else:
+            McpLoader._logger.error(
+                f"Unsupported transport protocol {source_cfg.transport} "
+                f"for MCP source {source_id}"
+            )
+            return None
+
+        con["headers"] = {}
+
+        if source_cfg.headers:
+            con["headers"].update(
+                {
+                    header_name: header_value.get_secret_value()
+                    for header_name, header_value in source_cfg.headers.items()
+                    if header_name.lower() != "authorization"
+                }
+            )
+
+        if source_cfg.forward_token:
+            auth_override = (
+                source_cfg.forward_auth_override.get_secret_value()
+                if source_cfg.forward_auth_override
+                else None
+            )
+
+            con["auth"] = McpBearerAuthProvider(
+                uid=user_info.user_id,
+                token=user_info.token,
+                auth_override=auth_override,
+            )
+
+        header_names = sorted(con["headers"].keys())
+        McpLoader._logger.info(
+            f"Header names configured for source '{source_id}': {header_names}"
+        )
+
+        return con
+
+    @staticmethod
+    def _apply_tool_customizations(
+        wrapped_tool: BaseTool,
+        source_id: str,
+        source_config: MCPSourceConfig,
+    ) -> None:
+        """Apply description overrides and group metadata to a wrapped MCP tool in place."""
+        # Attempt to load detailed tool descriptions for this mcp-source
+        # this is optional and only used to enrich the tool metadata with a more detailed description, if available
+        # The idea is that by customizing the mcp tool description files,
+        # we can provide better, e.g. usecase specific, descriptions for the tools
+        # We found that the descriptions provided by the MCP sources themselves are often not sufficient for good performance,
+        # so this is a way to enrich them
+        config_descriptions = source_config.descriptions or []
+        custom_desc_entry = next(
+            (d for d in config_descriptions if d.name == wrapped_tool.name),
+            None,
+        )
+        custom_desc = custom_desc_entry.description if custom_desc_entry else None
+
+        existing_metadata = dict(getattr(wrapped_tool, "metadata", {}) or {})
+        old_description = existing_metadata.pop("description", None)
+
+        metadata = {
+            **existing_metadata,
+            "mcp_source": source_id,
+            "mcp_group": McpLoader._resolve_group(
+                tool_name=wrapped_tool.name,
+                source_config=source_config,
+            ),
+        }
+
+        if custom_desc:
+            metadata["description"] = custom_desc
+            wrapped_tool.description = custom_desc
+        elif old_description:
+            metadata["description"] = old_description
+            wrapped_tool.description = old_description
+
+        wrapped_tool.metadata = metadata
+
+    @staticmethod
+    def _wrap_raw_tools(
+        raw_by_source: dict[str, list[MCPTool]],
+        user_info: AuthenticationResult,
+        sources: dict[str, MCPSourceConfig],
+    ) -> list[BaseTool]:
+        """Turn cached-or-fresh raw tool metadata into live, invocable LangChain tools.
+
+        Runs on every return path (cache hit, fresh fetch, lock-wait fallback) since the
+        connection/auth attached here is always rebuilt live and never itself cached.
+        """
+        tools: list[BaseTool] = []
+
+        for source_id, raw_tools in raw_by_source.items():
+            source_cfg = sources.get(source_id)
+            if source_cfg is None:
+                McpLoader._logger.warning(
+                    f"Cached MCP source '{source_id}' is no longer configured; skipping"
+                )
+                continue
+
+            con = McpLoader._build_connection(source_id, source_cfg, user_info)
+            if con is None:
+                continue
+
+            for raw_tool in raw_tools:
+                try:
+                    wrapped_tool = convert_mcp_tool_to_langchain_tool(
+                        session=None,
+                        tool=raw_tool,
+                        connection=con,
+                        server_name=source_id,
+                    )
+                    McpLoader._apply_tool_customizations(
+                        wrapped_tool, source_id, source_cfg
+                    )
+                    tools.append(wrapped_tool)
+                except Exception as e:
+                    McpLoader._logger.error(
+                        f"Failed to wrap cached MCP tool '{raw_tool.name}' from '{source_id}'",
+                        exc_info=e,
+                    )
+
+        return tools
 
     @staticmethod
     def _resolve_group(tool_name: str, source_config: MCPSourceConfig) -> str | None:

--- a/mucgpt-core-service/app/agent/tools/mcp.py
+++ b/mucgpt-core-service/app/agent/tools/mcp.py
@@ -110,9 +110,12 @@ class McpLoader:
             failed_sources: set[str] = set()
 
             for source_id, source_cfg in sources.items():
+                # Deliberately omit source_cfg.url: some MCP source conventions put
+                # API keys in the query string, and logging the full URL would open
+                # a second place for that secret to leak besides Redis.
                 McpLoader._logger.info(
                     f"Configuring MCP connection for source '{source_id}' "
-                    f"with transport '{source_cfg.transport}' and url '{source_cfg.url}'"
+                    f"with transport '{source_cfg.transport}'"
                 )
 
                 con = McpLoader._build_connection(source_id, source_cfg, user_info)

--- a/mucgpt-core-service/tests/unit/test_mcp_loader.py
+++ b/mucgpt-core-service/tests/unit/test_mcp_loader.py
@@ -1,4 +1,5 @@
-from contextlib import asynccontextmanager
+from collections.abc import AsyncIterator, Callable, Iterator
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from unittest.mock import AsyncMock, patch
 
 import cloudpickle
@@ -12,10 +13,11 @@ from core.auth_models import AuthenticationResult
 
 SECRET_HEADER_VALUE = "supersecretheadervalue123"
 SECRET_OVERRIDE_VALUE = "supersecretoverridevalue456"
+FORWARDED_TOKEN_VALUE = "supersecretforwardedtoken789"
 
 
 class FakeSession:
-    def __init__(self, pages: list[list[MCPTool]]):
+    def __init__(self, pages: list[list[MCPTool]]) -> None:
         self._pages = pages
 
     async def initialize(self) -> None:
@@ -29,10 +31,10 @@ class FakeSession:
 
 
 class FakeLock:
-    def __init__(self, raise_on_enter: Exception | None = None):
+    def __init__(self, raise_on_enter: Exception | None = None) -> None:
         self._raise_on_enter = raise_on_enter
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> "FakeLock":
         if self._raise_on_enter:
             raise self._raise_on_enter
         return self
@@ -42,7 +44,7 @@ class FakeLock:
 
 
 class FakeRedis:
-    def __init__(self, raise_on_enter: Exception | None = None):
+    def __init__(self, raise_on_enter: Exception | None = None) -> None:
         self._raise_on_enter = raise_on_enter
 
     def lock(self, name: str, timeout: int, blocking_timeout: int) -> FakeLock:
@@ -51,9 +53,11 @@ class FakeRedis:
 
 def make_fake_create_session(
     sessions_by_url: dict[str, FakeSession], fail_urls: frozenset[str] = frozenset()
-):
+) -> Callable[..., AbstractAsyncContextManager[FakeSession]]:
     @asynccontextmanager
-    async def _fake_create_session(connection, *, mcp_callbacks=None):
+    async def _fake_create_session(
+        connection, *, mcp_callbacks=None
+    ) -> AsyncIterator[FakeSession]:
         url = connection["url"]
         if url in fail_urls:
             raise RuntimeError(f"simulated connection failure for {url}")
@@ -84,7 +88,7 @@ def make_user(uid: str = "u1", token: str = "user-jwt-token") -> AuthenticationR
 
 
 @pytest.fixture(autouse=True)
-def reset_token_store():
+def reset_token_store() -> Iterator[None]:
     McpBearerAuthProvider._tokens.clear()
     yield
     McpBearerAuthProvider._tokens.clear()
@@ -223,7 +227,9 @@ class TestLoadMcpTools:
                 "agent.tools.mcp.RedisCache.set_object", AsyncMock()
             ) as mock_set_object,
         ):
-            tools = await McpLoader.load_mcp_tools(make_user(), force_reload=True)
+            tools = await McpLoader.load_mcp_tools(
+                make_user(token=FORWARDED_TOKEN_VALUE), force_reload=True
+            )
 
         assert len(tools) == 1
         mock_set_object.assert_called_once()
@@ -235,6 +241,9 @@ class TestLoadMcpTools:
         dumped = cloudpickle.dumps(cached_obj)
         assert SECRET_HEADER_VALUE.encode() not in dumped
         assert SECRET_OVERRIDE_VALUE.encode() not in dumped
+        # The forwarded user bearer token is a secret too, not just static config
+        # headers/overrides - make sure it's just as absent from what gets cached.
+        assert FORWARDED_TOKEN_VALUE.encode() not in dumped
 
     @pytest.mark.asyncio
     async def test_partial_failure_caches_only_successful_sources_short_ttl(
@@ -341,6 +350,10 @@ class TestLoadMcpTools:
         cached_raw = {"src": [MCPTool(name="a", inputSchema={"type": "object"})]}
 
         create_session_mock = AsyncMock(side_effect=AssertionError("should not connect"))
+        # Spy on the real _build_connection rather than stubbing it out, so we can
+        # prove the live connection/auth is rebuilt fresh on this cache-hit path -
+        # never reused or reconstructed from anything that came out of Redis.
+        original_build_connection = McpLoader._build_connection
 
         with (
             patch("agent.tools.mcp.create_session", create_session_mock),
@@ -348,10 +361,14 @@ class TestLoadMcpTools:
                 "agent.tools.mcp.RedisCache.get_object",
                 AsyncMock(return_value=cached_raw),
             ),
+            patch.object(
+                McpLoader, "_build_connection", side_effect=original_build_connection
+            ) as build_connection_spy,
         ):
             tools = await McpLoader.load_mcp_tools(make_user(), force_reload=False)
 
         create_session_mock.assert_not_called()
+        build_connection_spy.assert_called_once()
         assert len(tools) == 1
         assert tools[0].name == "a"
         assert tools[0].metadata["mcp_source"] == "src"

--- a/mucgpt-core-service/tests/unit/test_mcp_loader.py
+++ b/mucgpt-core-service/tests/unit/test_mcp_loader.py
@@ -1,0 +1,378 @@
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import cloudpickle
+import pytest
+from mcp.types import ListToolsResult
+from mcp.types import Tool as MCPTool
+
+from agent.tools.mcp import McpBearerAuthProvider, McpLoader
+from config.settings import MCPConfig, MCPSourceConfig, MCPTransport
+from core.auth_models import AuthenticationResult
+
+SECRET_HEADER_VALUE = "supersecretheadervalue123"
+SECRET_OVERRIDE_VALUE = "supersecretoverridevalue456"
+
+
+class FakeSession:
+    def __init__(self, pages: list[list[MCPTool]]):
+        self._pages = pages
+
+    async def initialize(self) -> None:
+        return None
+
+    async def list_tools(self, cursor: str | None = None) -> ListToolsResult:
+        index = int(cursor) if cursor else 0
+        page = self._pages[index]
+        next_cursor = str(index + 1) if index + 1 < len(self._pages) else None
+        return ListToolsResult(tools=page, nextCursor=next_cursor)
+
+
+class FakeLock:
+    def __init__(self, raise_on_enter: Exception | None = None):
+        self._raise_on_enter = raise_on_enter
+
+    async def __aenter__(self):
+        if self._raise_on_enter:
+            raise self._raise_on_enter
+        return self
+
+    async def __aexit__(self, *args) -> bool:
+        return False
+
+
+class FakeRedis:
+    def __init__(self, raise_on_enter: Exception | None = None):
+        self._raise_on_enter = raise_on_enter
+
+    def lock(self, name: str, timeout: int, blocking_timeout: int) -> FakeLock:
+        return FakeLock(self._raise_on_enter)
+
+
+def make_fake_create_session(
+    sessions_by_url: dict[str, FakeSession], fail_urls: frozenset[str] = frozenset()
+):
+    @asynccontextmanager
+    async def _fake_create_session(connection, *, mcp_callbacks=None):
+        url = connection["url"]
+        if url in fail_urls:
+            raise RuntimeError(f"simulated connection failure for {url}")
+        yield sessions_by_url[url]
+
+    return _fake_create_session
+
+
+def make_source(
+    url: str,
+    forward_token: bool = False,
+    forward_auth_override: str | None = None,
+    headers: dict[str, str] | None = None,
+) -> MCPSourceConfig:
+    return MCPSourceConfig(
+        url=url,
+        transport=MCPTransport.SSE,
+        forward_token=forward_token,
+        forward_auth_override=forward_auth_override,
+        headers=headers,
+    )
+
+
+def make_user(uid: str = "u1", token: str = "user-jwt-token") -> AuthenticationResult:
+    return AuthenticationResult(
+        token=token, user_id=uid, department="IT", name="Test User", roles=["mucgpt-user"]
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_token_store():
+    McpBearerAuthProvider._tokens.clear()
+    yield
+    McpBearerAuthProvider._tokens.clear()
+
+
+class TestBuildConnection:
+    def test_sse_with_static_headers_and_forwarded_token(self):
+        source_cfg = make_source(
+            "http://mcp.example/sse",
+            forward_token=True,
+            headers={"X-Api-Key": SECRET_HEADER_VALUE},
+        )
+        user_info = make_user()
+
+        con = McpLoader._build_connection("src", source_cfg, user_info)
+
+        assert con is not None
+        assert con["headers"] == {"X-Api-Key": SECRET_HEADER_VALUE}
+        assert isinstance(con["auth"], McpBearerAuthProvider)
+
+    def test_authorization_header_key_is_dropped(self):
+        source_cfg = make_source(
+            "http://mcp.example/sse", headers={"Authorization": "should-be-ignored"}
+        )
+
+        con = McpLoader._build_connection("src", source_cfg, make_user())
+
+        assert con["headers"] == {}
+
+    def test_no_forward_token_means_no_auth_key(self):
+        source_cfg = make_source("http://mcp.example/sse", forward_token=False)
+
+        con = McpLoader._build_connection("src", source_cfg, make_user())
+
+        assert "auth" not in con
+
+    def test_unsupported_transport_returns_none(self):
+        source_cfg = make_source("http://mcp.example/sse")
+        object.__setattr__(source_cfg, "transport", "stdio")
+
+        con = McpLoader._build_connection("src", source_cfg, make_user())
+
+        assert con is None
+
+
+class TestApplyToolCustomizations:
+    def test_custom_description_overrides_and_group_is_resolved(self):
+        from langchain_core.tools import StructuredTool
+
+        source_cfg = MCPSourceConfig(
+            url="http://x",
+            transport=MCPTransport.SSE,
+            group="default-group",
+            tool_groups={"search_": "search-group"},
+            descriptions=[
+                {"name": "search_docs", "description": "Custom enriched description"}
+            ],
+        )
+        tool = StructuredTool(
+            name="search_docs",
+            description="original description",
+            args_schema={"type": "object", "properties": {}},
+            coroutine=AsyncMock(),
+        )
+
+        McpLoader._apply_tool_customizations(tool, "src", source_cfg)
+
+        assert tool.description == "Custom enriched description"
+        assert tool.metadata["description"] == "Custom enriched description"
+        assert tool.metadata["mcp_group"] == "search-group"
+        assert tool.metadata["mcp_source"] == "src"
+
+
+class TestWrapRawTools:
+    def test_skips_source_no_longer_configured(self):
+        raw_by_source = {"stale_source": [MCPTool(name="a", inputSchema={"type": "object"})]}
+
+        tools = McpLoader._wrap_raw_tools(raw_by_source, make_user(), sources={})
+
+        assert tools == []
+
+    def test_produces_invocable_tool_with_live_auth(self):
+        sources = {
+            "src": make_source(
+                "http://mcp.example/sse", forward_token=True, headers={"X-Api-Key": "h1"}
+            )
+        }
+        raw_by_source = {"src": [MCPTool(name="a", inputSchema={"type": "object"})]}
+
+        tools = McpLoader._wrap_raw_tools(raw_by_source, make_user(uid="u1"), sources)
+
+        assert len(tools) == 1
+        assert tools[0].name == "a"
+        assert tools[0].metadata["mcp_source"] == "src"
+
+
+class TestListAllToolsForSession:
+    @pytest.mark.asyncio
+    async def test_follows_pagination(self):
+        page1 = [MCPTool(name="a", inputSchema={"type": "object"})]
+        page2 = [MCPTool(name="b", inputSchema={"type": "object"})]
+        session = FakeSession(pages=[page1, page2])
+
+        tools = await McpLoader._list_all_tools_for_session(session)
+
+        assert [t.name for t in tools] == ["a", "b"]
+
+
+class TestLoadMcpTools:
+    @pytest.mark.asyncio
+    async def test_no_secret_material_is_ever_cached(self, monkeypatch):
+        source_cfg = make_source(
+            "http://mcp.example/sse",
+            forward_token=True,
+            forward_auth_override=SECRET_OVERRIDE_VALUE,
+            headers={"X-Api-Key": SECRET_HEADER_VALUE},
+        )
+        monkeypatch.setattr(
+            McpLoader,
+            "_mcp_settings",
+            MCPConfig(SOURCES={"src": source_cfg}, CACHE_TTL=100),
+        )
+
+        fake_session = FakeSession(
+            pages=[[MCPTool(name="a", inputSchema={"type": "object"})]]
+        )
+        fake_create_session = make_fake_create_session({"http://mcp.example/sse": fake_session})
+
+        with (
+            patch("agent.tools.mcp.create_session", fake_create_session),
+            patch(
+                "agent.tools.mcp.RedisCache.get_redis",
+                AsyncMock(return_value=FakeRedis()),
+            ),
+            patch(
+                "agent.tools.mcp.RedisCache.set_object", AsyncMock()
+            ) as mock_set_object,
+        ):
+            tools = await McpLoader.load_mcp_tools(make_user(), force_reload=True)
+
+        assert len(tools) == 1
+        mock_set_object.assert_called_once()
+        cached_obj = mock_set_object.call_args.kwargs["obj"]
+
+        assert isinstance(cached_obj, dict)
+        assert isinstance(cached_obj["src"][0], MCPTool)
+
+        dumped = cloudpickle.dumps(cached_obj)
+        assert SECRET_HEADER_VALUE.encode() not in dumped
+        assert SECRET_OVERRIDE_VALUE.encode() not in dumped
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_caches_only_successful_sources_short_ttl(
+        self, monkeypatch
+    ):
+        good = make_source("http://good/sse")
+        bad = make_source("http://bad/sse")
+        monkeypatch.setattr(
+            McpLoader,
+            "_mcp_settings",
+            MCPConfig(SOURCES={"good": good, "bad": bad}, CACHE_TTL=100),
+        )
+
+        fake_session = FakeSession(
+            pages=[[MCPTool(name="a", inputSchema={"type": "object"})]]
+        )
+        fake_create_session = make_fake_create_session(
+            {"http://good/sse": fake_session}, fail_urls=frozenset({"http://bad/sse"})
+        )
+
+        with (
+            patch("agent.tools.mcp.create_session", fake_create_session),
+            patch(
+                "agent.tools.mcp.RedisCache.get_redis",
+                AsyncMock(return_value=FakeRedis()),
+            ),
+            patch(
+                "agent.tools.mcp.RedisCache.set_object", AsyncMock()
+            ) as mock_set_object,
+        ):
+            tools = await McpLoader.load_mcp_tools(make_user(), force_reload=True)
+
+        assert len(tools) == 1
+        assert tools[0].metadata["mcp_source"] == "good"
+        mock_set_object.assert_called_once()
+        assert mock_set_object.call_args.kwargs["ttl"] == 60
+        cached_obj = mock_set_object.call_args.kwargs["obj"]
+        assert list(cached_obj.keys()) == ["good"]
+
+    @pytest.mark.asyncio
+    async def test_all_sources_fail_returns_empty_without_caching(self, monkeypatch):
+        bad = make_source("http://bad/sse")
+        monkeypatch.setattr(
+            McpLoader, "_mcp_settings", MCPConfig(SOURCES={"bad": bad}, CACHE_TTL=100)
+        )
+        fake_create_session = make_fake_create_session(
+            {}, fail_urls=frozenset({"http://bad/sse"})
+        )
+
+        with (
+            patch("agent.tools.mcp.create_session", fake_create_session),
+            patch(
+                "agent.tools.mcp.RedisCache.get_redis",
+                AsyncMock(return_value=FakeRedis()),
+            ),
+            patch(
+                "agent.tools.mcp.RedisCache.set_object", AsyncMock()
+            ) as mock_set_object,
+        ):
+            tools = await McpLoader.load_mcp_tools(make_user(), force_reload=True)
+
+        assert tools == []
+        mock_set_object.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_wraps_without_refetching(self, monkeypatch):
+        source_cfg = make_source(
+            "http://mcp.example/sse", forward_token=True, headers={"X-Api-Key": "live-secret"}
+        )
+        monkeypatch.setattr(
+            McpLoader,
+            "_mcp_settings",
+            MCPConfig(SOURCES={"src": source_cfg}, CACHE_TTL=100),
+        )
+        cached_raw = {"src": [MCPTool(name="a", inputSchema={"type": "object"})]}
+
+        create_session_mock = AsyncMock(side_effect=AssertionError("should not connect"))
+
+        with (
+            patch("agent.tools.mcp.create_session", create_session_mock),
+            patch(
+                "agent.tools.mcp.RedisCache.get_object",
+                AsyncMock(return_value=cached_raw),
+            ),
+        ):
+            tools = await McpLoader.load_mcp_tools(make_user(), force_reload=False)
+
+        create_session_mock.assert_not_called()
+        assert len(tools) == 1
+        assert tools[0].name == "a"
+        assert tools[0].metadata["mcp_source"] == "src"
+
+    @pytest.mark.asyncio
+    async def test_stale_cached_source_is_skipped_not_raised(self, monkeypatch):
+        monkeypatch.setattr(
+            McpLoader,
+            "_mcp_settings",
+            MCPConfig(SOURCES={}, CACHE_TTL=100),
+        )
+        cached_raw = {
+            "removed_source": [MCPTool(name="a", inputSchema={"type": "object"})]
+        }
+
+        with patch(
+            "agent.tools.mcp.RedisCache.get_object", AsyncMock(return_value=cached_raw)
+        ):
+            tools = await McpLoader.load_mcp_tools(make_user(), force_reload=False)
+
+        assert tools == []
+
+    @pytest.mark.asyncio
+    async def test_lock_contention_falls_back_to_uncached_load(self, monkeypatch):
+        source_cfg = make_source("http://mcp.example/sse")
+        monkeypatch.setattr(
+            McpLoader,
+            "_mcp_settings",
+            MCPConfig(SOURCES={"src": source_cfg}, CACHE_TTL=100),
+        )
+        fake_session = FakeSession(
+            pages=[[MCPTool(name="a", inputSchema={"type": "object"})]]
+        )
+        fake_create_session = make_fake_create_session({"http://mcp.example/sse": fake_session})
+
+        from redis.exceptions import LockError
+
+        with (
+            patch("agent.tools.mcp.create_session", fake_create_session),
+            patch("agent.tools.mcp.asyncio.sleep", AsyncMock()),
+            patch(
+                "agent.tools.mcp.RedisCache.get_redis",
+                AsyncMock(return_value=FakeRedis(raise_on_enter=LockError("locked"))),
+            ),
+            patch(
+                "agent.tools.mcp.RedisCache.get_object", AsyncMock(return_value=None)
+            ),
+            patch("agent.tools.mcp.RedisCache.set_object", AsyncMock()),
+        ):
+            tools = await McpLoader.load_mcp_tools(make_user(), force_reload=False)
+
+        assert len(tools) == 1
+        assert tools[0].name == "a"

--- a/mucgpt-core-service/tests/unit/test_mcp_loader.py
+++ b/mucgpt-core-service/tests/unit/test_mcp_loader.py
@@ -300,6 +300,35 @@ class TestLoadMcpTools:
         mock_set_object.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_unsupported_transport_source_counts_as_failed_not_cached(
+        self, monkeypatch
+    ):
+        """A source with an unsupported transport must not be treated as a healthy
+        empty result. Otherwise an all-unsupported config would cache [] with the
+        full TTL instead of the short-TTL failure path used for real failures."""
+        unsupported = make_source("http://unsupported/sse")
+        object.__setattr__(unsupported, "transport", "stdio")
+        monkeypatch.setattr(
+            McpLoader,
+            "_mcp_settings",
+            MCPConfig(SOURCES={"unsupported": unsupported}, CACHE_TTL=100),
+        )
+
+        with (
+            patch(
+                "agent.tools.mcp.RedisCache.get_redis",
+                AsyncMock(return_value=FakeRedis()),
+            ),
+            patch(
+                "agent.tools.mcp.RedisCache.set_object", AsyncMock()
+            ) as mock_set_object,
+        ):
+            tools = await McpLoader.load_mcp_tools(make_user(), force_reload=True)
+
+        assert tools == []
+        mock_set_object.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_cache_hit_wraps_without_refetching(self, monkeypatch):
         source_cfg = make_source(
             "http://mcp.example/sse", forward_token=True, headers={"X-Api-Key": "live-secret"}


### PR DESCRIPTION
## Summary
- `McpLoader` used to cache fully-assembled MCP tool objects in Redis, which carried live connection headers/auth (including plaintext secret header values and forwarded bearer tokens) for the full `CACHE_TTL`.
- Only secret-free raw tool metadata (name/description/inputSchema) is now cached; `_build_connection` (the only place credentials are materialized) is called fresh from current config + `AuthenticationResult` on every call path, cache hit or miss, and its result is never persisted.
- Tool discovery (`_list_all_tools_for_session`) is reimplemented locally to follow MCP pagination without depending on `langchain_mcp_adapters`' private helpers, since that dependency is pinned with an unbounded upper version.

Fixes #1089.

## Why
Any MCP source configured with static secret headers, or with `forward_token` enabled (forwarding a user's bearer token), risked having those credentials written to Redis in plaintext and outliving the request that produced them — readable by anything with Redis access.

## Validation
- [x] Automated tests
- [ ] Manual verification
- [ ] Not applicable

Added `tests/unit/test_mcp_loader.py`, including assertions that configured secret header/override values never appear in what gets written to the cache, across the cache-miss, cache-hit, partial-failure, and lock-contention paths. `uv run pytest` and `uv run ruff check` pass.

## UI Changes (If applicable)
Not applicable — backend-only change.

## Change Areas
- [x] Core service

## Risks / Rollout Notes
Behavior for callers is unchanged (same tool objects returned); only what gets persisted to Redis changes. Existing cached entries from before this change may still contain full tool objects with credentials until they naturally expire under the old `CACHE_TTL` — operators handling sensitive MCP source secrets may want to flush the `mcp_tools:*` Redis keys after deploying this fix.

## References
Related to the ongoing MCP/tool integration work on `feat/retrieval-tool`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved MCP tool loading across multiple sources, including paginated discovery and smarter partial-success caching.

* **Bug Fixes**
  * Prevented failures from stale or removed sources by skipping unsupported/unconfigured tools gracefully.
  * Enhanced cache lock behavior with rechecks and bounded retry; falls back to live loading when needed.
  * Redis caching no longer stores sensitive auth/header details; tools are re-wrapped from cached metadata on each use.

* **Tests**
  * Added unit coverage for session listing, connection/auth behavior, tool customization, caching/lock fallbacks, and secure wrapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->