### PR TITLE
Show creator and subscriber count for subscribed assistants

### DIFF
--- a/mucgpt-assistant-service/app/api/api_models.py
+++ b/mucgpt-assistant-service/app/api/api_models.py
@@ -617,6 +617,10 @@ class SubscriptionResponse(BaseModel):
         description="Whether this assistant is publicly listed in the UI",
         example=True,
     )
+    owners_detailed: list[OwnerDetailsResponse] | None = Field(
+        None,
+        description="Owner details enriched from LDAP",
+    )
 
     # replaced inner Config with model_config
     model_config = ConfigDict(

--- a/mucgpt-assistant-service/app/api/routers/users_router.py
+++ b/mucgpt-assistant-service/app/api/routers/users_router.py
@@ -283,10 +283,17 @@ async def get_user_subscriptions(
 
     # Build simplified response with only ID and name
     response_list = []
+    owner_lookup_cache: dict[str, dict[str, object]] = {}
     for assistant in assistants:
         assistant_id = str(assistant.id)
         latest_version = assistant.versions[0] if assistant.versions else None
         if latest_version:
+            owner_ids = [owner.user_id for owner in assistant.owners]
+            owners_detailed = await build_owner_details(
+                owner_ids,
+                owner_lookup_cache,
+                owners=assistant.owners,
+            )
             response = SubscriptionResponse(
                 id=assistant_id,
                 title=getattr(latest_version, "name", ""),
@@ -295,6 +302,7 @@ async def get_user_subscriptions(
                 subscriptions_count=getattr(assistant, "subscriptions_count", 0) or 0,
                 tags=latest_version.tags or [],
                 is_visible=bool(getattr(assistant, "is_visible", True)),
+                owners_detailed=owners_detailed,
             )
             response_list.append(response)
 

--- a/mucgpt-frontend/src/api/models.ts
+++ b/mucgpt-frontend/src/api/models.ts
@@ -273,6 +273,7 @@ export type CommunityAssistant = {
     subscriptions_count?: number;
     tags?: string[];
     is_visible?: boolean;
+    owners_detailed?: OwnerDetailsResponse[];
 };
 
 export type CommunityAssistantSnapshot = {

--- a/mucgpt-frontend/src/components/CodeBlockRenderer/CodeBlockRenderer.tsx
+++ b/mucgpt-frontend/src/components/CodeBlockRenderer/CodeBlockRenderer.tsx
@@ -95,12 +95,7 @@ export default function CodeBlockRenderer(props: CodeBlockRendererProps) {
                 />
                 <div className={styles.copyContainer}>
                     {language}
-                    <Button
-                        appearance="transparent"
-                        aria-label="Copy code"
-                        icon={copied ? <CheckmarkSquare24Regular /> : <Copy24Regular />}
-                        onClick={onCopy}
-                    />
+                    <Button appearance="transparent" aria-label="Copy code" icon={copied ? <CheckmarkSquare24Regular /> : <Copy24Regular />} onClick={onCopy} />
                 </div>
             </div>
         );

--- a/mucgpt-frontend/src/components/OwnerMetadataLink/OwnerMetadataLink.tsx
+++ b/mucgpt-frontend/src/components/OwnerMetadataLink/OwnerMetadataLink.tsx
@@ -7,7 +7,7 @@ type OwnerSource = {
     owners_detailed?: OwnerDetailsResponse[];
     latest_version?: {
         owners_detailed?: OwnerDetailsResponse[];
-    };
+    } | null;
 };
 
 interface OwnerMetadataLinkProps {
@@ -15,17 +15,19 @@ interface OwnerMetadataLinkProps {
     fallbackLabel?: string;
 }
 
-export function getPrimaryOwnerDetails(source: OwnerSource | null | undefined): OwnerDetailsResponse | undefined {
+export function getPrimaryOwnerDetails(source: OwnerSource | object | null | undefined): OwnerDetailsResponse | undefined {
     if (!source) {
         return undefined;
     }
 
-    if (source.owners_detailed && source.owners_detailed.length > 0) {
-        return source.owners_detailed[0];
+    const { owners_detailed, latest_version } = source as OwnerSource;
+
+    if (owners_detailed && owners_detailed.length > 0) {
+        return owners_detailed[0];
     }
 
-    if (source.latest_version?.owners_detailed && source.latest_version.owners_detailed.length > 0) {
-        return source.latest_version.owners_detailed[0];
+    if (latest_version?.owners_detailed && latest_version.owners_detailed.length > 0) {
+        return latest_version.owners_detailed[0];
     }
 
     return undefined;

--- a/mucgpt-frontend/src/pages/discovery/Discovery.tsx
+++ b/mucgpt-frontend/src/pages/discovery/Discovery.tsx
@@ -421,9 +421,7 @@ const Discovery = () => {
             title={assistant.title}
             description={assistant.description}
             badges={getAssistantBadges(assistant)}
-            metadataStartNode={
-                <OwnerMetadataLink owner={getPrimaryOwnerDetails(assistant.rawData)} fallbackLabel={getMetadataFallbackLabel(assistant)} />
-            }
+            metadataStartNode={<OwnerMetadataLink owner={getPrimaryOwnerDetails(assistant.rawData)} fallbackLabel={getMetadataFallbackLabel(assistant)} />}
             subscriberCount={assistant.subscriptions}
             isPrivate={isAssistantPrivate(assistant)}
             privateLabel={t("components.community_assistants.private_label", "Privat")}

--- a/mucgpt-frontend/src/pages/discovery/Discovery.tsx
+++ b/mucgpt-frontend/src/pages/discovery/Discovery.tsx
@@ -422,10 +422,7 @@ const Discovery = () => {
             description={assistant.description}
             badges={getAssistantBadges(assistant)}
             metadataStartNode={
-                <OwnerMetadataLink
-                    owner={getPrimaryOwnerDetails("latest_version" in assistant.rawData ? assistant.rawData : undefined)}
-                    fallbackLabel={getMetadataFallbackLabel(assistant)}
-                />
+                <OwnerMetadataLink owner={getPrimaryOwnerDetails(assistant.rawData)} fallbackLabel={getMetadataFallbackLabel(assistant)} />
             }
             subscriberCount={assistant.subscriptions}
             isPrivate={isAssistantPrivate(assistant)}

--- a/mucgpt-frontend/src/pages/discovery/hooks/useDiscoveryAssistantLists.ts
+++ b/mucgpt-frontend/src/pages/discovery/hooks/useDiscoveryAssistantLists.ts
@@ -3,6 +3,7 @@ import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useRef, useS
 import { getAllCommunityAssistantsApi, getOwnedCommunityAssistants, getUserSubscriptionsApi } from "../../../api/assistant-client";
 import { Assistant, AssistantResponse, CommunityAssistant, CommunityAssistantSnapshot } from "../../../api/models";
 import type { AssistantCardData } from "../../../components/AssistantDetailsSidebar/AssistantDetailsSidebar";
+import { getPrimaryOwnerDetails } from "../../../components/OwnerMetadataLink/OwnerMetadataLink";
 import { AssistantStorageService } from "../../../service/assistantstorage";
 import { CommunityAssistantStorageService } from "../../../service/communityassistantstorage";
 import useDebounce from "../../../hooks/debouncehook";
@@ -281,11 +282,20 @@ export const useDiscoveryAssistantLists = ({
                                 return null;
                             }
 
-                            return toCardData(assistantData, {
+                            // The chosen source (e.g. a locally cached snapshot) may not carry owner
+                            // details, while the subscription payload does. Preserve the subscription's
+                            // owner details so the card can still render the creator.
+                            const cardData = toCardData(assistantData, {
                                 subscriptions: fullData?.subscriptions_count ?? sub.subscriptions_count ?? 0,
                                 updated: fullData?.updated_at ?? (localData ? getSnapshotUpdatedAt(localData) : undefined) ?? sub.updated_at,
                                 isSubscribedAssistant: true
                             });
+
+                            if (getPrimaryOwnerDetails(cardData.rawData) === undefined && sub.owners_detailed && sub.owners_detailed.length > 0) {
+                                cardData.rawData = { ...cardData.rawData, owners_detailed: sub.owners_detailed };
+                            }
+
+                            return cardData;
                         })
                         .filter((assistant): assistant is AssistantCardData => assistant !== null)
                 ];

--- a/mucgpt-frontend/src/pages/discovery/hooks/useDiscoveryAssistantLists.ts
+++ b/mucgpt-frontend/src/pages/discovery/hooks/useDiscoveryAssistantLists.ts
@@ -282,7 +282,7 @@ export const useDiscoveryAssistantLists = ({
                             }
 
                             return toCardData(assistantData, {
-                                subscriptions: fullData?.subscriptions_count ?? 0,
+                                subscriptions: fullData?.subscriptions_count ?? sub.subscriptions_count ?? 0,
                                 updated: fullData?.updated_at ?? (localData ? getSnapshotUpdatedAt(localData) : undefined) ?? sub.updated_at,
                                 isSubscribedAssistant: true
                             });


### PR DESCRIPTION
## Summary
What changed?
Fixed a bug where the subscribed assistants dont show the assistants creator and subscriber count in the discovery list. 

## Why
Why is this change needed?
Consistency & UI/UX 

## Validation
How was this verified?
- [ ] Automated tests
- [x] Manual verification
- [ ] Not applicable

## UI Changes (If applicable)
*Please add screenshots or screencasts of any visual changes.*

## Change Areas
- [x] Frontend
- [ ] Core service
- [x] Assistant service
- [ ] Migrations / DB
- [ ] Infrastructure / Docker / Compose / Keycloak
- [ ] CI / CD
- [ ] Docs

## Risks / Rollout Notes
Is there anything reviewers or operators should pay attention to?
*Examples: breaking changes, config changes, migration order, deployment considerations, rollback concerns.*

## References
Related: #
Closes: #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enriched `owners_detailed` information to subscription responses and community assistant details, when available.
  * Updated discovery listings to surface enriched owner metadata using the best available owner details source.

* **Bug Fixes**
  * Improved subscriber count handling so existing counts are preserved when detailed data is partially missing.
  * Enhanced owner-metadata selection to handle different payload shapes and fall back between available owner sources correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->