### PR TITLE
Kickoff State-Persistancy: fontend generated conversation ID

### DIFF
--- a/mucgpt-core-service/app/api/api_models.py
+++ b/mucgpt-core-service/app/api/api_models.py
@@ -88,6 +88,10 @@ class ChatCompletionRequest(BaseModel):
     assistant_id: str | None = Field(
         None, description="ID of the assistant to use for this completion request"
     )
+    conversation_id: str | None = Field(
+        None,
+        description="Stable client-generated id for this conversation. Accepted but not yet used server-side.",
+    )
     data_sources: list[ChatDataSource] | None = Field(
         None,
         description="Structured document payload with title, content and metadata",

--- a/mucgpt-core-service/app/api/routers/chat_router.py
+++ b/mucgpt-core-service/app/api/routers/chat_router.py
@@ -85,6 +85,8 @@ async def chat_completions(
     # user-scoped tool/runtime cache while keeping assistant/chat-specific
     # enabled tools, prompts, data sources, and policy state request-scoped.
     ae = await init_agent(user_info=user_info)
+    if request.conversation_id:
+        logger.debug("Received conversation_id=%s", request.conversation_id)
     try:
         # Convert creativity to temperature
         temperature = get_temperature_from_request(request)

--- a/mucgpt-core-service/app/api/routers/chat_router.py
+++ b/mucgpt-core-service/app/api/routers/chat_router.py
@@ -86,7 +86,11 @@ async def chat_completions(
     # enabled tools, prompts, data sources, and policy state request-scoped.
     ae = await init_agent(user_info=user_info)
     if request.conversation_id:
-        logger.debug("Received conversation_id=%s", request.conversation_id)
+        logger.debug(
+            "Received conversation_id=%s",
+            request.conversation_id,
+            extra={"conversation_id": request.conversation_id},
+        )
     try:
         # Convert creativity to temperature
         temperature = get_temperature_from_request(request)

--- a/mucgpt-core-service/tests/unit/test_api_models.py
+++ b/mucgpt-core-service/tests/unit/test_api_models.py
@@ -1,0 +1,20 @@
+from api.api_models import ChatCompletionRequest
+
+
+class TestChatCompletionRequestConversationId:
+    """conversation_id is optional and must not affect existing behavior."""
+
+    def test_conversation_id_defaults_to_none(self):
+        request = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert request.conversation_id is None
+
+    def test_conversation_id_is_accepted_when_provided(self):
+        request = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            conversation_id="6f3a1e2c-9b7d-4a3f-9e3a-2c1b9d8f6a10",
+        )
+
+        assert request.conversation_id == "6f3a1e2c-9b7d-4a3f-9e3a-2c1b9d8f6a10"

--- a/mucgpt-core-service/tests/unit/test_api_models.py
+++ b/mucgpt-core-service/tests/unit/test_api_models.py
@@ -4,14 +4,14 @@ from api.api_models import ChatCompletionRequest
 class TestChatCompletionRequestConversationId:
     """conversation_id is optional and must not affect existing behavior."""
 
-    def test_conversation_id_defaults_to_none(self):
+    def test_conversation_id_defaults_to_none(self) -> None:
         request = ChatCompletionRequest(
             messages=[{"role": "user", "content": "hi"}],
         )
 
         assert request.conversation_id is None
 
-    def test_conversation_id_is_accepted_when_provided(self):
+    def test_conversation_id_is_accepted_when_provided(self) -> None:
         request = ChatCompletionRequest(
             messages=[{"role": "user", "content": "hi"}],
             conversation_id="6f3a1e2c-9b7d-4a3f-9e3a-2c1b9d8f6a10",

--- a/mucgpt-frontend/src/api/core-client.ts
+++ b/mucgpt-frontend/src/api/core-client.ts
@@ -40,6 +40,7 @@ export async function chatApi(options: ChatRequest): Promise<Response> {
         creativity?: string;
         enabled_tools?: string[];
         assistant_id?: string;
+        conversation_id?: string;
         data_sources?: ChatRequest["data_sources"];
     } = {
         model: options.model,
@@ -53,6 +54,9 @@ export async function chatApi(options: ChatRequest): Promise<Response> {
     }
     if (options.assistant_id) {
         body.assistant_id = options.assistant_id;
+    }
+    if (options.conversation_id) {
+        body.conversation_id = options.conversation_id;
     }
     if (options.data_sources) {
         body.data_sources = options.data_sources;

--- a/mucgpt-frontend/src/api/models.ts
+++ b/mucgpt-frontend/src/api/models.ts
@@ -41,6 +41,7 @@ export type ChatRequest = {
     model?: string;
     enabled_tools?: string[];
     assistant_id?: string;
+    conversation_id?: string;
     data_sources?: DataSource[];
 };
 

--- a/mucgpt-frontend/src/pages/page_helpers.ts
+++ b/mucgpt-frontend/src/pages/page_helpers.ts
@@ -237,6 +237,12 @@ export const makeApiRequest = async (
     // Create conversation history for the API request
     const history: ChatTurn[] = answers.map((a: { user: any; response: { answer: any } }) => ({ user: a.user, assistant: a.response.answer }));
 
+    // Normal-chat conversation id: reuse the active local chat id when continuing
+    // an existing chat, otherwise generate one now so it can be sent with the
+    // first request too (instead of only after the first response). Assistant
+    // chats are out of scope for now.
+    const conversationId = assistant_id ? undefined : (activeChatRef.current ?? uuid());
+
     // Build the API request object
     const request: ChatRequest = {
         history: [...history, { user: question, assistant: undefined }],
@@ -247,6 +253,7 @@ export const makeApiRequest = async (
         model: LLM.llm_name,
         enabled_tools: enabled_tools && enabled_tools.length > 0 ? enabled_tools : undefined,
         assistant_id: assistant_id,
+        conversation_id: conversationId,
         data_sources: data_sources && data_sources.length > 0 ? data_sources : undefined
     };
 
@@ -453,10 +460,12 @@ export const makeApiRequest = async (
         // Create a new chat with generated name
         const chatname = await createChatName(question, finalResponse.answer, options.system ?? "");
 
-        // Create chat with assistant-specific ID if assistant_id is provided, otherwise use regular UUID
+        // Create chat with assistant-specific ID if assistant_id is provided, otherwise
+        // reuse the id already generated above (and sent as conversation_id) for a
+        // regular chat, so the local id matches what the backend was sent.
         const id = assistant_id
             ? await storageService.create([finalMessage], options, AssistantStorageService.GENERATE_BOT_CHAT_ID(assistant_id, uuid()), chatname, false)
-            : await storageService.create([finalMessage], options, uuid(), chatname, false);
+            : await storageService.create([finalMessage], options, conversationId ?? uuid(), chatname, false);
 
         // Set the new chat as active and refresh history
         dispatch({ type: "SET_ACTIVE_CHAT", payload: id });


### PR DESCRIPTION

## Summary

Frontend now generates a stable, client-side conversation_id (UUID) up front for normal chats — reused as the local IndexedDB chat id and sent on every /v1/chat/completions request. Backend accepts the new optional conversation_id field on ChatCompletionRequest and logs it at debug level; no persistence logic added.

## Why

Stage 1 of the backend chat-persistence rollout. Gives every later persistence stage a stable id to key off, without changing any visible behavior. Deliberately the first, independently-mergeable PR in that backlog.

## Validation

- [x] Automated tests
- [x] Manual verification
- [ ] Not applicable

## UI Changes (If applicable)

None — no visible behavior change.

## Change Areas

- [x] Frontend
- [x] Core service
- [ ] Assistant service
- [ ] Migrations / DB
- [ ] Infrastructure / Docker / Compose / Keycloak
- [ ] CI / CD
- [ ] Docs

## Risks / Rollout Notes

Low risk — additive, optional field on both sides; no persistence, no schema/DB changes, assistant chats out of scope for now. Safe to deploy alone ahead of the rest of the persistence backlog.

## References
Related: #
Closes: #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat API requests now accept an optional, client-generated `conversation_id` for standard conversations.
  * When continuing a chat, the frontend reuses the active conversation identifier; new conversations generate one before the first request.
  * Assistant-specific chats keep their existing behavior (no `conversation_id` sent).
* **Bug Fixes**
  * Improved alignment between locally saved chat IDs and the conversation identifier used for initial standard chat requests.
* **Tests**
  * Added unit tests covering default and provided `conversation_id` handling.
* **Chores**
  * Added debug logging when `conversation_id` is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->