### PR TITLE
chore: remove best-practices section from terms of use

### DIFF
--- a/mucgpt-frontend/src/components/TermsOfUseDialog/TermsOfUseDialog.tsx
+++ b/mucgpt-frontend/src/components/TermsOfUseDialog/TermsOfUseDialog.tsx
@@ -132,14 +132,6 @@ export const TermsOfUseDialog = ({ defaultOpen, onAccept, showTrigger = true, tr
                                         .
                                     </li>
                                 )}
-                                <li>
-                                    <strong>Best-Practice Dokumentation/Wissensmanagement:</strong> Erfolgreiche Anwendungsfälle von MUCGPT sollen dokumentiert
-                                    werden, um wertvolles Wissen für zukünftige Projekte zu generieren. Tragen Sie diese Beispiele gerne{" "}
-                                    <Link inline className={styles.link} href="https://wilma.muenchen.de/workspaces/innovationcenter/apps/list/best-practices">
-                                        hier
-                                    </Link>{" "}
-                                    ein.
-                                </li>
                             </ul>
                             <div className={styles.responsibleContainer}>
                                 Verantwortlich für die Nutzungsbedingungen ist RIT-IV-2 Compliance und Policies. Bei Fragen oder Anmerkungen hierzu bitte an


### PR DESCRIPTION
## Summary
Remove outdated best-practices section from Terms of Use dialog.

## Why
Section is no longer maintained and no longer relevant.

## Validation
How was this verified?
- [ ] Automated tests
- [x] Manual verification
- [ ] Not applicable

## UI Changes (If applicable)
*Please add screenshots or screencasts of any visual changes.*

## Change Areas
- [x] Frontend
- [ ] Core service
- [ ] Assistant service
- [ ] Migrations / DB
- [ ] Infrastructure / Docker / Compose / Keycloak
- [ ] CI / CD
- [ ] Docs

## Risks / Rollout Notes
Is there anything reviewers or operators should pay attention to?
*Examples: breaking changes, config changes, migration order, deployment considerations, rollback concerns.*

## References
Related: #
Closes: #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the “Best-Practice Dokumentation/Wissensmanagement” item from the Terms of Use dialog.
  * The remaining terms and optional FAQs section are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->