### PR TITLE
pin mcpdoc dependency "mcp" to <v2.

### DIFF
--- a/stack/mcpdoc-server/Dockerfile
+++ b/stack/mcpdoc-server/Dockerfile
@@ -42,7 +42,7 @@ ENV UV_TOOL_HOME=/opt/uv \
     PATH="/home/mcpuser/.local/bin:${PATH}"
 
 # Install mcpdoc as non-root user
-RUN uv tool install --force mcpdoc && \
+RUN uv tool install --force mcpdoc --with "mcp>=1.28,<2" && \
     uv tool list
 
 # Remove proxy variables from runtime environment


### PR DESCRIPTION

## Summary
pinned mcpdoc dependency "mcp" to <v2. 


## Why
mcp v2 changes cause mcpdoc to crash with a module not found error

## Validation
How was this verified?
- [ ] Automated tests
- [x] Manual verification
- [ ] Not applicable

## Change Areas
- [ ] Frontend
- [ ] Core service
- [ ] Assistant service
- [ ] Migrations / DB
- [x] Infrastructure / Docker / Compose / Keycloak
- [ ] CI / CD
- [ ] Docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled MCP tooling to use a compatible version range, improving build consistency and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->