### PR TITLE
Chore/pin mcpdoc deps in pyproject file

### DIFF
--- a/mucgpt-core-service/app/agent/agent_executor.py
+++ b/mucgpt-core-service/app/agent/agent_executor.py
@@ -8,7 +8,7 @@ from langchain_core.messages import (
 )
 from langchain_core.runnables import RunnableConfig
 from langchain_core.runnables.config import merge_configs
-from langfuse import observe, propagate_attributes
+from langfuse import get_client, observe, propagate_attributes
 from langfuse.langchain import CallbackHandler
 
 from agent.react_agent import MUCGPTReActAgent
@@ -142,6 +142,13 @@ class MUCGPTAgentExecutor:
             tags=tags,
             session_id=conversation_id
         ):
+            # capture_input/output are disabled on @observe above to avoid
+            # duplicating the full resent history; set a lightweight
+            # trace-level summary instead so it isn't blank in the UI.
+            get_client().update_current_span(
+                input=messages[-1].content if messages else None
+            )
+            answer_chunks: list[str] = []
             config = merge_configs(
                 self.base_config,
                 RunnableConfig(
@@ -196,6 +203,8 @@ class MUCGPTAgentExecutor:
                             else:
                                 # If content is not a string (e.g., list for multimodal), keep existing behavior and pass through.
                                 pass
+                            if isinstance(chunk_content, str):
+                                answer_chunks.append(chunk_content)
                             yield ChatCompletionChunk(
                                 id=id_,
                                 object="chat.completion.chunk",
@@ -226,6 +235,7 @@ class MUCGPTAgentExecutor:
                         )
                         continue
                 logger.debug("Streaming completed successfully.")
+                get_client().update_current_span(output="".join(answer_chunks))
             except Exception as ex:
                 logger.error("Streaming error: %s", str(ex), exc_info=True)
                 error_msg = llm_exception_handler(ex=ex, logger=logger)
@@ -310,6 +320,13 @@ class MUCGPTAgentExecutor:
                 llm = self.agent.model.with_config(config)
                 ai_message = llm.invoke(msgs)
                 logger.info("Non-streaming completed successfully.")
+                # capture_input/output are disabled on @observe above to avoid
+                # duplicating the full resent history; set a lightweight
+                # trace-level summary instead so it isn't blank in the UI.
+                get_client().update_current_span(
+                    input=messages[-1].content if messages else None,
+                    output=ai_message.content,
+                )
                 response = ChatCompletionResponse(
                     id=str(uuid.uuid4()),
                     object="chat.completion",

--- a/mucgpt-core-service/app/agent/agent_executor.py
+++ b/mucgpt-core-service/app/agent/agent_executor.py
@@ -116,6 +116,7 @@ class MUCGPTAgentExecutor:
         enabled_tools: list[str] | None = None,
         assistant_id: str | None = None,
         data_sources: list[dict[str, Any]] | None = None,
+        conversation_id: str | None = None
     ) -> AsyncGenerator[dict]:
         logger.info(
             "Chat streaming started with temperature %s, model %s",
@@ -139,6 +140,7 @@ class MUCGPTAgentExecutor:
         with propagate_attributes(
             user_id=hash_user_id(user_info.user_id if user_info else None),
             tags=tags,
+            session_id=conversation_id
         ):
             config = merge_configs(
                 self.base_config,
@@ -265,6 +267,7 @@ class MUCGPTAgentExecutor:
         enabled_tools: list[str] | None = None,
         assistant_id: str | None = None,
         data_sources: list[dict[str, Any]] | None = None,
+        conversation_id: str | None = None
     ) -> ChatCompletionResponse:
         logger.info(
             "Chat non-streaming started with temperature %s, model %s",
@@ -285,6 +288,7 @@ class MUCGPTAgentExecutor:
         with propagate_attributes(
             user_id=hash_user_id(user_info.user_id if user_info else None),
             tags=tags,
+            session_id=conversation_id
         ):
             request_config = RunnableConfig(
                 configurable={

--- a/mucgpt-core-service/app/api/routers/chat_router.py
+++ b/mucgpt-core-service/app/api/routers/chat_router.py
@@ -113,6 +113,7 @@ async def chat_completions(
                 enabled_tools=enabled_tools,
                 assistant_id=request.assistant_id,
                 data_sources=data_sources,
+                conversation_id=request.conversation_id
             )
 
             async def sse_generator():
@@ -129,6 +130,7 @@ async def chat_completions(
                 enabled_tools=enabled_tools,
                 assistant_id=request.assistant_id,
                 data_sources=data_sources,
+                conversation_id=request.conversation_id
             )
     except Exception as e:
         logger.exception("Exception in /chat/completions")

--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -278,10 +278,6 @@ services:
       HTTPS_PROXY: ${HTTPS_PROXY:-}
       https_proxy: ${HTTPS_PROXY:-}
     command:
-      - tool
-      - run
-      - --from
-      - mcpdoc
       - mcpdoc
       - --urls
       - "KI in München:https://ki.muenchen.de/llms.txt"

--- a/stack/mcpdoc-server/Dockerfile
+++ b/stack/mcpdoc-server/Dockerfile
@@ -37,13 +37,16 @@ RUN useradd -m -u 1000 -s /bin/bash mcpuser && \
 USER mcpuser
 WORKDIR /home/mcpuser
 
+COPY --chown=mcpuser:mcpuser pyproject.toml ./
+
 # Set environment for uv
 ENV UV_TOOL_HOME=/opt/uv \
+    UV_PROJECT_ENVIRONMENT=/opt/uv/mcpdoc \
     PATH="/home/mcpuser/.local/bin:${PATH}"
 
-# Install mcpdoc as non-root user
-RUN uv tool install --force mcpdoc && \
-    uv tool list
+# Install mcpdoc project dependencies as non-root user
+RUN uv sync --no-dev --no-install-project && \
+    uv run --no-sync mcpdoc --help
 
 # Remove proxy variables from runtime environment
 ENV HTTP_PROXY= \
@@ -52,4 +55,4 @@ ENV HTTP_PROXY= \
     http_proxy= \
     https_proxy=
 
-ENTRYPOINT ["uv"]
+ENTRYPOINT ["uv", "run", "--no-sync"]

--- a/stack/mcpdoc-server/pyproject.toml
+++ b/stack/mcpdoc-server/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "mucgpt-mcpdoc-server"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "mcpdoc==0.0.10",
+    "mcp==1.29.0",
+]


### PR DESCRIPTION
## Summary
pin mcpdoc deps in pyproject file

## Why
pin mcpdoc deps in pyproject file instead of dockerfile

## Validation
How was this verified?
- [ ] Automated tests
- [x] Manual verification
- [ ] Not applicable


## Change Areas
- [ ] Frontend
- [ ] Core service
- [ ] Assistant service
- [ ] Migrations / DB
- [x] Infrastructure / Docker / Compose / Keycloak
- [ ] CI / CD
- [ ] Docs



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversation identifiers are now carried through both streaming and standard chat responses for improved session continuity.
  * Chat activity now captures lightweight input and output details for enhanced conversation monitoring.

* **Bug Fixes**
  * Improved handling of streamed assistant content to ensure complete responses are recorded.

* **Chores**
  * Updated the documentation server container setup for more consistent builds and startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->