### PR TITLE
Refactor get_internal_task_model to accept strength as a string and e…

### DIFF
--- a/mucgpt-core-service/app/core/llm_helpers.py
+++ b/mucgpt-core-service/app/core/llm_helpers.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 
 from config.langfuse_provider import LangfuseProvider
 from config.model_provider import ModelProvider
-from config.settings import InternalTaskModelStrength, Settings
+from config.settings import Settings
 from core.auth_models import AuthenticationResult
 from core.logtools import getLogger
 

--- a/mucgpt-core-service/app/core/llm_helpers.py
+++ b/mucgpt-core-service/app/core/llm_helpers.py
@@ -67,7 +67,7 @@ def extract_message_content(content: Any) -> str:
 
 
 def get_internal_task_model(
-    settings: Settings, strength: InternalTaskModelStrength
+    settings: Settings, strength: str
 ) -> str:
     """Return the preferred configured model for an internal LLM task."""
 
@@ -170,7 +170,6 @@ async def invoke_internal_structured_generation[StructuredOutputT: BaseModel](
 
     llm = (
         ModelProvider.get_model()
-        .with_structured_output(schema)
         .with_config(
             _internal_request_config(
                 model_name=model_name,
@@ -179,6 +178,7 @@ async def invoke_internal_structured_generation[StructuredOutputT: BaseModel](
                 run_name=run_name,
             )
         )
+        .with_structured_output(schema)
     )
     with propagate_attributes(
         user_id=hash_user_id(user_info.user_id),


### PR DESCRIPTION

## Summary
Refactor get_internal_task_model to accept strength as a string and ensure structured output is consistently applied in invoke_internal_structured_generation.

## Why
appying the structured output before the model config chooses the default model and never selects the model defined in the config!

## Validation
How was this verified?
- [ ] Automated tests
- [x] Manual verification
- [ ] Not applicable

## Change Areas
- [ ] Frontend
- [x] Core service
- [ ] Assistant service
- [ ] Migrations / DB
- [ ] Infrastructure / Docker / Compose / Keycloak
- [ ] CI / CD
- [ ] Docs



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved structured response generation by applying request configuration before schema-based formatting.
  * Updated internal model selection to accept strength values more flexibly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->