### PR TITLE
Fix chat resize with sidebar

### DIFF
--- a/mucgpt-frontend/src/components/ChatLayout/ChatLayout.module.css
+++ b/mucgpt-frontend/src/components/ChatLayout/ChatLayout.module.css
@@ -92,14 +92,16 @@
     flex: 1;
     min-height: 0;
     margin-top: 60px;
+    margin-right: 0;
     overflow: hidden;
     z-index: 1;
     box-sizing: border-box;
     background: var(--colorNeutralBackground1);
+    transition: margin-right 280ms cubic-bezier(0.33, 1, 0.68, 1);
 }
 
 .container[data-info-open="true"] .chatRoot {
-    right: var(--assistantDetailsDrawerWidth);
+    margin-right: var(--assistantDetailsDrawerWidth);
 }
 
 .chatContainer {
@@ -290,10 +292,13 @@
     }
 
     .container[data-info-open="true"] .headerBar,
-    .container[data-info-open="true"] .chatRoot,
     .container[data-info-open="true"] .scrollToBottomWrapper,
     .container[data-info-open="true"] .chatInput {
         right: var(--assistantDetailsDrawerCompactWidth);
+    }
+
+    .container[data-info-open="true"] .chatRoot {
+        margin-right: var(--assistantDetailsDrawerCompactWidth);
     }
 }
 
@@ -323,10 +328,13 @@
 
 @media (max-width: 600px) {
     .container[data-info-open="true"] .headerBar,
-    .container[data-info-open="true"] .chatRoot,
     .container[data-info-open="true"] .scrollToBottomWrapper,
     .container[data-info-open="true"] .chatInput {
         right: 0;
+    }
+
+    .container[data-info-open="true"] .chatRoot {
+        margin-right: 0;
     }
 }
 
@@ -345,5 +353,9 @@
 
     .scrollToBottomButton {
         transition: opacity 0.01ms linear;
+    }
+
+    .chatRoot {
+        transition: none;
     }
 }


### PR DESCRIPTION
## Summary
Chat layout resize correctly when the 'AssistantDetailsSidebar' is open. 

## Why
'AssistantDetailSidebar' overlapped the chat.

## Validation
How was this verified?
- [ ] Automated tests
- [ ] Manual verification
- [ ] Not applicable

## UI Changes (If applicable)
<img width="1615" height="880" alt="image" src="https://github.com/user-attachments/assets/18ce3da5-da2d-44b1-95e5-7fa9c5204634" />

## Change Areas
- [x] Frontend
- [ ] Core service
- [ ] Assistant service
- [ ] Migrations / DB
- [ ] Infrastructure / Docker / Compose / Keycloak
- [ ] CI / CD
- [ ] Docs

## Risks / Rollout Notes
Is there anything reviewers or operators should pay attention to?
*Examples: breaking changes, config changes, migration order, deployment considerations, rollback concerns.*

## References
Related: #
Closes: #
