### PR TITLE
encrypted user metadata tracing

### DIFF
--- a/mucgpt-assistant-service/app/core/auth.py
+++ b/mucgpt-assistant-service/app/core/auth.py
@@ -170,9 +170,6 @@ def authenticate_user(
     try:
         logger.info("Authenticating user")
         user_info = auth_helper.authenticate(authorization)
-        logger.info(
-            f"User authenticated successfully: {user_info.name} from {user_info.department}"
-        )
         return user_info
     except AuthError as e:
         logger.error(f"Authentication failed: {e.error}")

--- a/mucgpt-core-service/app/agent/agent_executor.py
+++ b/mucgpt-core-service/app/agent/agent_executor.py
@@ -28,6 +28,7 @@ from api.api_models import ChatCompletionMessage as InputMessage
 from api.exception import llm_exception_handler
 from config.langfuse_provider import LangfuseProvider
 from core.auth_models import AuthenticationResult
+from core.crypto import encrypted_user_metadata
 from core.llm_helpers import (
     extract_department_prefix,
     hash_user_id,
@@ -213,6 +214,7 @@ class MUCGPTAgentExecutor:
             user_id=hash_user_id(user_info.user_id if user_info else None),
             tags=tags,
             session_id=conversation_id,
+            metadata=encrypted_user_metadata(user_info),
         ):
             # capture_input/output are disabled on @observe above to avoid
             # duplicating the full resent history; set a lightweight
@@ -411,6 +413,7 @@ class MUCGPTAgentExecutor:
             user_id=hash_user_id(user_info.user_id if user_info else None),
             tags=tags,
             session_id=conversation_id,
+            metadata=encrypted_user_metadata(user_info),
         ):
             token_usage = TokenUsage()
             request_config = RunnableConfig(

--- a/mucgpt-core-service/app/config/settings.py
+++ b/mucgpt-core-service/app/config/settings.py
@@ -70,7 +70,10 @@ class ModelInfo(BaseModel):
 
     @model_validator(mode="after")
     def check_threshold_order(self) -> "ModelInfo":
-        if self.context_warning_threshold_percent >= self.context_critical_threshold_percent:
+        if (
+            self.context_warning_threshold_percent
+            >= self.context_critical_threshold_percent
+        ):
             raise ValueError(
                 "context_warning_threshold_percent must be lower than "
                 "context_critical_threshold_percent"
@@ -354,6 +357,12 @@ class LangfuseConfig(BaseModel):
     HOST: str | None = None
 
 
+class UserTraceConfig(BaseModel):
+    """Encrypted user identity configuration for Langfuse traces."""
+
+    PUBLIC_KEY: str | None = None
+
+
 class MCPToolDescription(BaseModel):
     """Configuration for overriding an MCP tool's description."""
 
@@ -495,6 +504,7 @@ class Settings(BaseSettings):
     # Nested sub-configurations
     SSO: SSOConfig = Field(default_factory=SSOConfig)
     LANGFUSE: LangfuseConfig = Field(default_factory=LangfuseConfig)
+    USER_TRACE: UserTraceConfig = Field(default_factory=UserTraceConfig)
     MCP: MCPConfig = Field(default_factory=MCPConfig)
     REDIS: RedisConfig = Field(default_factory=RedisConfig)
     INTERNET_SEARCH: InternetSearchConfig = Field(default_factory=InternetSearchConfig)

--- a/mucgpt-core-service/app/core/crypto.py
+++ b/mucgpt-core-service/app/core/crypto.py
@@ -1,0 +1,82 @@
+import base64
+import json
+import os
+from functools import lru_cache
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from config.settings import get_settings
+from core.auth_models import AuthenticationResult
+
+_METADATA_CHUNK_SIZE = 190
+
+
+@lru_cache(maxsize=1)
+def _load_public_key(public_key_value: str) -> rsa.RSAPublicKey:
+    public_key = serialization.load_pem_public_key(
+        base64.b64decode(public_key_value, validate=True)
+    )
+    if not isinstance(public_key, rsa.RSAPublicKey):
+        raise ValueError("USER_TRACE.PUBLIC_KEY must be an RSA public key")
+    return public_key
+
+
+def validate_user_trace_public_key() -> None:
+    """Fail startup when the optional user-trace key is invalid."""
+    public_key_value = get_settings().USER_TRACE.PUBLIC_KEY
+    if public_key_value:
+        _load_public_key(public_key_value)
+
+
+def encrypted_user_metadata(
+    user_info: AuthenticationResult | None,
+) -> dict[str, str] | None:
+    """Encrypt trace identity with the configured public key."""
+    public_key_value = get_settings().USER_TRACE.PUBLIC_KEY
+    if user_info is None or not public_key_value:
+        return None
+
+    public_key = _load_public_key(public_key_value)
+
+    payload = json.dumps(
+        {
+            "v": 1,
+            "user_id": user_info.user_id,
+            "name": user_info.name,
+            "department": user_info.department,
+        },
+        separators=(",", ":"),
+    ).encode()
+    data_key = AESGCM.generate_key(bit_length=256)
+    nonce = os.urandom(12)
+    ciphertext = AESGCM(data_key).encrypt(nonce, payload, None)
+    encrypted_key = public_key.encrypt(
+        data_key,
+        padding.OAEP(
+            mgf=padding.MGF1(algorithm=hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=None,
+        ),
+    )
+    envelope = base64.urlsafe_b64encode(
+        json.dumps(
+            {
+                "v": 1,
+                "key": base64.urlsafe_b64encode(encrypted_key).decode(),
+                "nonce": base64.urlsafe_b64encode(nonce).decode(),
+                "data": base64.urlsafe_b64encode(ciphertext).decode(),
+            },
+            separators=(",", ":"),
+        ).encode()
+    ).decode()
+    chunks = [
+        envelope[index : index + _METADATA_CHUNK_SIZE]
+        for index in range(0, len(envelope), _METADATA_CHUNK_SIZE)
+    ]
+    metadata = {
+        f"encrypted_user_{index:02d}": chunk for index, chunk in enumerate(chunks)
+    }
+    metadata["encrypted_user_parts"] = str(len(chunks))
+    return metadata

--- a/mucgpt-core-service/app/core/llm_helpers.py
+++ b/mucgpt-core-service/app/core/llm_helpers.py
@@ -14,6 +14,7 @@ from config.langfuse_provider import LangfuseProvider
 from config.model_provider import ModelRegistry
 from config.settings import Settings
 from core.auth_models import AuthenticationResult
+from core.crypto import encrypted_user_metadata
 from core.logtools import getLogger
 
 logger = getLogger()
@@ -69,9 +70,7 @@ def extract_message_content(content: Any) -> str:
     return str(content)
 
 
-def get_internal_task_model(
-    settings: Settings, strength: str
-) -> str:
+def get_internal_task_model(settings: Settings, strength: str) -> str:
     """Return the preferred configured model for an internal LLM task."""
 
     if not settings.MODELS:
@@ -161,8 +160,11 @@ async def invoke_internal_generation(
     with propagate_attributes(
         user_id=hash_user_id(user_info.user_id),
         tags=trace_tags,
+        metadata=encrypted_user_metadata(user_info),
     ):
-        ai_message = await llm.ainvoke(to_langchain_messages(messages), config=run_config)
+        ai_message = await llm.ainvoke(
+            to_langchain_messages(messages), config=run_config
+        )
 
     return extract_message_content(ai_message.content)
 
@@ -198,5 +200,6 @@ async def invoke_internal_structured_generation[StructuredOutputT: BaseModel](
     with propagate_attributes(
         user_id=hash_user_id(user_info.user_id),
         tags=trace_tags,
+        metadata=encrypted_user_metadata(user_info),
     ):
-        return await llm.ainvoke(to_langchain_messages(messages), config=run_config) # type: ignore
+        return await llm.ainvoke(to_langchain_messages(messages), config=run_config)  # type: ignore

--- a/mucgpt-core-service/app/init_app.py
+++ b/mucgpt-core-service/app/init_app.py
@@ -14,6 +14,7 @@ from config.settings import (
 )
 from core.auth_models import AuthenticationResult
 from core.cache import RedisCache
+from core.crypto import validate_user_trace_public_key
 from core.logtools import getLogger
 
 logger = getLogger()
@@ -47,6 +48,7 @@ class ModelOptions:
 async def warmup_app() -> None:
     logger.info("Warming up app context...")
     settings = get_settings()
+    validate_user_trace_public_key()
     # init model metadata
     _initialize_models_metadata(settings)
     # init model

--- a/mucgpt-core-service/config.yaml.example
+++ b/mucgpt-core-service/config.yaml.example
@@ -93,6 +93,11 @@ LANGFUSE:
   SECRET_KEY: "<your-secret-key>"
   HOST: "https://langfuse.example.com"
 
+# Optional RSA public key for recoverable user identity on Langfuse traces.
+# Supply a base64-encoded PEM via MUCGPT_CORE_USER_TRACE__PUBLIC_KEY in production.
+USER_TRACE:
+  PUBLIC_KEY: null
+
 # MCP Settings (optional - nested under MCP key)
 MCP:
   SOURCES:

--- a/mucgpt-core-service/pyproject.toml
+++ b/mucgpt-core-service/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "cloudpickle>=3.1.2",
     "python-multipart>=0.0.5",
     "deepagents>=0.7.6",
+    "cryptography>=50.0.0",
 ]
 
 [dependency-groups]

--- a/mucgpt-core-service/tests/unit/test_agent_executor.py
+++ b/mucgpt-core-service/tests/unit/test_agent_executor.py
@@ -7,6 +7,7 @@ from langchain_core.messages import AIMessage, AIMessageChunk, ToolCall
 from agent.agent_executor import MUCGPTAgentExecutor
 from agent.tools.tool_chunk import ToolStreamChunk, ToolStreamState
 from api.api_models import ChatCompletionMessage as InputMessage
+from core.auth_models import AuthenticationResult
 
 
 class DummyLLM:
@@ -275,6 +276,36 @@ class TestMUCGPTAgentExecutor:
         assert config["llm"] == "test-model"
         assert config["llm_streaming"] is False
         assert config["enabled_tools"] == ["simplify"]
+
+    @pytest.mark.asyncio
+    async def test_run_without_streaming_propagates_encrypted_user_metadata(
+        self, monkeypatch
+    ):
+        propagated = {}
+        monkeypatch.setattr(
+            "agent.agent_executor.encrypted_user_metadata",
+            lambda _user: {"encrypted_user_00": "ciphertext"},
+        )
+        monkeypatch.setattr(
+            "agent.agent_executor.propagate_attributes",
+            lambda **kwargs: propagated.update(kwargs) or nullcontext(),
+        )
+        user = AuthenticationResult(
+            token="secret",
+            user_id="12345",
+            name="Jane Doe",
+            department="ITM-AI",
+        )
+
+        await self.runner.run_without_streaming(
+            messages=[InputMessage(role="user", content="hi")],
+            temperature=0.5,
+            model="test-model",
+            user_info=user,
+        )
+
+        assert propagated["metadata"] == {"encrypted_user_00": "ciphertext"}
+        assert propagated["user_id"] != user.user_id
 
     @pytest.mark.asyncio
     async def test_run_without_streaming_returns_error_on_exception(self):

--- a/mucgpt-core-service/tests/unit/test_crypto.py
+++ b/mucgpt-core-service/tests/unit/test_crypto.py
@@ -1,0 +1,91 @@
+import base64
+import json
+from types import SimpleNamespace
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from core.auth_models import AuthenticationResult
+from core.crypto import encrypted_user_metadata, validate_user_trace_public_key
+
+
+@pytest.fixture
+def keypair():
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_pem = private_key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_key, base64.b64encode(public_pem).decode()
+
+
+def _settings(public_key):
+    return SimpleNamespace(USER_TRACE=SimpleNamespace(PUBLIC_KEY=public_key))
+
+
+def test_encrypted_user_metadata_round_trip(monkeypatch, keypair):
+    private_key, public_key = keypair
+    monkeypatch.setattr("core.crypto.get_settings", lambda: _settings(public_key))
+    user = AuthenticationResult(
+        token="secret",
+        user_id="12345",
+        name="Jane Doe",
+        department="ITM-AI",
+    )
+
+    metadata = encrypted_user_metadata(user)
+
+    assert metadata is not None
+    assert all(len(value) <= 200 for value in metadata.values())
+    chunks = int(metadata["encrypted_user_parts"])
+    token = "".join(metadata[f"encrypted_user_{index:02d}"] for index in range(chunks))
+    envelope = json.loads(base64.urlsafe_b64decode(token))
+    data_key = private_key.decrypt(
+        base64.urlsafe_b64decode(envelope["key"]),
+        padding.OAEP(
+            mgf=padding.MGF1(algorithm=hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=None,
+        ),
+    )
+    payload = AESGCM(data_key).decrypt(
+        base64.urlsafe_b64decode(envelope["nonce"]),
+        base64.urlsafe_b64decode(envelope["data"]),
+        None,
+    )
+
+    assert json.loads(payload) == {
+        "v": 1,
+        "user_id": "12345",
+        "name": "Jane Doe",
+        "department": "ITM-AI",
+    }
+    assert "secret" not in payload.decode()
+
+
+def test_encrypted_user_metadata_is_disabled_without_key(monkeypatch):
+    monkeypatch.setattr("core.crypto.get_settings", lambda: _settings(None))
+
+    assert encrypted_user_metadata(None) is None
+
+
+def test_encrypted_user_metadata_changes_for_each_trace(monkeypatch, keypair):
+    _, public_key = keypair
+    monkeypatch.setattr("core.crypto.get_settings", lambda: _settings(public_key))
+    user = AuthenticationResult(
+        token="secret",
+        user_id="12345",
+        name="Jane Doe",
+        department="ITM-AI",
+    )
+
+    assert encrypted_user_metadata(user) != encrypted_user_metadata(user)
+
+
+def test_invalid_public_key_fails_validation(monkeypatch):
+    monkeypatch.setattr("core.crypto.get_settings", lambda: _settings("invalid"))
+
+    with pytest.raises(ValueError):
+        validate_user_trace_public_key()

--- a/mucgpt-core-service/tests/unit/test_settings.py
+++ b/mucgpt-core-service/tests/unit/test_settings.py
@@ -458,6 +458,14 @@ class TestSettings:
             assert langfuse_settings.SECRET_KEY is None
             assert langfuse_settings.HOST is None
 
+    def test_user_trace_public_key(self):
+        with patch.dict(
+            os.environ,
+            {"MUCGPT_CORE_USER_TRACE__PUBLIC_KEY": "encoded-public-key"},
+        ):
+            get_settings.cache_clear()
+            assert get_settings().USER_TRACE.PUBLIC_KEY == "encoded-public-key"
+
     def test_mcp_settings(self):
         """Test MCP settings configuration via nested env vars."""
         mcp_json = json.dumps(

--- a/mucgpt-core-service/uv.lock
+++ b/mucgpt-core-service/uv.lock
@@ -1632,6 +1632,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "asgi-correlation-id" },
     { name = "cloudpickle" },
+    { name = "cryptography" },
     { name = "deepagents" },
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
@@ -1670,6 +1671,7 @@ dev = [
 requires-dist = [
     { name = "asgi-correlation-id", specifier = ">=4.3.4" },
     { name = "cloudpickle", specifier = ">=3.1.2" },
+    { name = "cryptography", specifier = ">=50.0.0" },
     { name = "deepagents", specifier = ">=0.7.6" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/stack/core.config.yaml.example
+++ b/stack/core.config.yaml.example
@@ -39,6 +39,11 @@ LANGFUSE:
   SECRET_KEY: "<your-sk>"
   PUBLIC_KEY: "<your-pk>"
 
+# Optional: base64-encoded RSA public key for encrypted trace identity.
+# Prefer MUCGPT_CORE_USER_TRACE__PUBLIC_KEY in production.
+USER_TRACE:
+  PUBLIC_KEY: null
+
 # MCP Settings (Model Context Protocol)
 # Used by core service for external tool integration
 MCP:

--- a/stack/core.config.yaml.example
+++ b/stack/core.config.yaml.example
@@ -40,7 +40,6 @@ LANGFUSE:
   PUBLIC_KEY: "<your-pk>"
 
 # Optional: base64-encoded RSA public key for encrypted trace identity.
-# Prefer MUCGPT_CORE_USER_TRACE__PUBLIC_KEY in production.
 USER_TRACE:
   PUBLIC_KEY: null
 


### PR DESCRIPTION
## Summary
- Added `encrypted_user_metadata` function for encrypting user identity.
- Introduced `UserTraceConfig` in settings for user trace public key.
- Validated user trace public key during app initialization.
- Updated agent executor to propagate encrypted user metadata.
- Added tests for user metadata encryption and public key validation.
- Updated configuration examples to include user trace settings.

## Why
somehow we need to be able to trace inputs/chats back to users in case of policy violations

## Validation
How was this verified?
- [x] Automated tests
- [x] Manual verification
- [ ] Not applicable

## Change Areas
- [ ] Frontend
- [x] Core service
- [ ] Assistant service
- [ ] Migrations / DB
- [ ] Infrastructure / Docker / Compose / Keycloak
- [ ] CI / CD
- [ ] Docs



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional encrypted user metadata to application traces, enabling authorized recovery of identity details while protecting sensitive information.
  * Added configuration support for an RSA public key used to secure trace metadata.
  * Invalid trace-encryption keys are now detected during application startup.

* **Bug Fixes**
  * Removed successful-authentication log output to reduce unnecessary sensitive logging.

* **Documentation**
  * Updated example configuration files with the new trace-security setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->