### PR TITLE
add chat deletion endpoint

### DIFF
--- a/mucgpt-core-service/app/api/routers/chat_router.py
+++ b/mucgpt-core-service/app/api/routers/chat_router.py
@@ -184,3 +184,43 @@ async def get_conversation_messages(
     if not messages:
         raise HTTPException(status_code=404, detail="Conversation not found")
     return messages
+
+
+@router.delete(
+    "/conversations/{conversation_id}",
+    summary="Delete conversation",
+    status_code=204,
+    responses={
+        403: {"description": "Forbidden"},
+        404: {"description": "Not found"},
+        500: {"description": "Internal Server Error"},
+    },
+)
+async def delete_conversation(
+    conversation_id: str,
+    user_info: Annotated[AuthenticationResult, Depends(authenticate_user)],
+) -> None:
+    """Delete the conversation: its ownership row and all LangGraph checkpoint state."""
+    if not await PersistanceHelpers.is_user_in_conversation(
+        user_info.user_id, conversation_id
+    ):
+        raise HTTPException(status_code=403, detail="Conversation access denied")
+
+    checkpointer = PersistanceHelpers.get_checkpointer_if_ready()
+    if checkpointer is None:
+        raise HTTPException(status_code=500, detail="Persistence not initialized")
+
+    deleted = await PersistanceHelpers.delete_conversation_mapping(
+        conversation_id, user_info.user_id
+    )
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    # Ownership row is already gone;
+    # attempt to delete the checkpoint state, but don't fail if it fails.
+    try:
+        await checkpointer.adelete_thread(conversation_id)
+    except Exception:
+        logger.exception(
+            "Failed to delete checkpoint state for conversation %s", conversation_id
+        )

--- a/mucgpt-core-service/app/api/routers/chat_router.py
+++ b/mucgpt-core-service/app/api/routers/chat_router.py
@@ -201,6 +201,9 @@ async def delete_conversation(
     user_info: Annotated[AuthenticationResult, Depends(authenticate_user)],
 ) -> None:
     """Delete the conversation: its ownership row and all LangGraph checkpoint state."""
+    if not await PersistanceHelpers.conversation_exists(conversation_id):
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
     if not await PersistanceHelpers.is_user_in_conversation(
         user_info.user_id, conversation_id
     ):

--- a/mucgpt-core-service/app/core/persistance_helpers.py
+++ b/mucgpt-core-service/app/core/persistance_helpers.py
@@ -143,6 +143,19 @@ class PersistanceHelpers:
             return await cur.fetchone() is not None
 
     @staticmethod
+    async def conversation_exists(conversation_id: str) -> bool:
+        """Check whether a conversation exists without checking its owner."""
+        pool = PersistanceHelpers._pool
+        if pool is None:
+            raise RuntimeError("PersistanceHelpers not initialized")
+        async with pool.connection() as conn:
+            cur = await conn.execute(
+                "SELECT 1 FROM chats WHERE conversation_id = %s",
+                (conversation_id,),
+            )
+            return await cur.fetchone() is not None
+
+    @staticmethod
     async def get_conversation_messages(
         conversation_id: str,
     ) -> list[ChatCompletionMessage]:

--- a/mucgpt-core-service/app/core/persistance_helpers.py
+++ b/mucgpt-core-service/app/core/persistance_helpers.py
@@ -169,3 +169,16 @@ class PersistanceHelpers:
                         ChatCompletionMessage(role="assistant", content=content)
                     )
         return result
+
+    @staticmethod
+    async def delete_conversation_mapping(conversation_id: str, user_id: str) -> bool:
+        """Delete the conversation mapping row. Returns True if a row was deleted."""
+        pool = PersistanceHelpers._pool
+        if pool is None:
+            raise RuntimeError("PersistanceHelpers not initialized")
+        async with pool.connection() as conn:
+            cur = await conn.execute(
+                "DELETE FROM chats WHERE conversation_id = %s AND user_id = %s RETURNING 1",
+                (conversation_id, user_id),
+            )
+            return await cur.fetchone() is not None

--- a/mucgpt-core-service/tests/integration/test_chat_router.py
+++ b/mucgpt-core-service/tests/integration/test_chat_router.py
@@ -42,6 +42,11 @@ def stub_persistence(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setattr(
         PersistanceHelpers,
+        "conversation_exists",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        PersistanceHelpers,
         "has_checkpoint",
         AsyncMock(return_value=False),
     )
@@ -258,9 +263,7 @@ class TestChatRouter:
             Mock(return_value=checkpointer),
         )
 
-        response = test_client.delete(
-            f"/v1/conversations/{DUMMY_CONVERSATION_ID}"
-        )
+        response = test_client.delete(f"/v1/conversations/{DUMMY_CONVERSATION_ID}")
 
         assert response.status_code == 204, response.text
         assert response.content == b""
@@ -278,9 +281,7 @@ class TestChatRouter:
             AsyncMock(return_value=False),
         )
 
-        response = test_client.delete(
-            f"/v1/conversations/{DUMMY_CONVERSATION_ID}"
-        )
+        response = test_client.delete(f"/v1/conversations/{DUMMY_CONVERSATION_ID}")
 
         assert response.status_code == 403
 
@@ -291,15 +292,36 @@ class TestChatRouter:
 
         monkeypatch.setattr(
             PersistanceHelpers,
+            "conversation_exists",
+            AsyncMock(return_value=False),
+        )
+        monkeypatch.setattr(
+            PersistanceHelpers,
             "delete_conversation_mapping",
             AsyncMock(return_value=False),
         )
 
-        response = test_client.delete(
-            f"/v1/conversations/{DUMMY_CONVERSATION_ID}"
-        )
+        response = test_client.delete(f"/v1/conversations/{DUMMY_CONVERSATION_ID}")
 
         assert response.status_code == 404
+
+    def test_delete_conversation_missing_is_not_forbidden(
+        self, test_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from core.persistance_helpers import PersistanceHelpers
+
+        monkeypatch.setattr(
+            PersistanceHelpers,
+            "conversation_exists",
+            AsyncMock(return_value=False),
+        )
+        is_user_mock = AsyncMock(return_value=False)
+        monkeypatch.setattr(PersistanceHelpers, "is_user_in_conversation", is_user_mock)
+
+        response = test_client.delete(f"/v1/conversations/{DUMMY_CONVERSATION_ID}")
+
+        assert response.status_code == 404
+        is_user_mock.assert_not_awaited()
 
     def test_delete_conversation_persistence_not_ready(
         self, test_client: TestClient, monkeypatch: pytest.MonkeyPatch
@@ -312,9 +334,7 @@ class TestChatRouter:
             Mock(return_value=None),
         )
 
-        response = test_client.delete(
-            f"/v1/conversations/{DUMMY_CONVERSATION_ID}"
-        )
+        response = test_client.delete(f"/v1/conversations/{DUMMY_CONVERSATION_ID}")
 
         assert response.status_code == 500
 
@@ -338,9 +358,7 @@ class TestChatRouter:
             Mock(return_value=checkpointer),
         )
 
-        response = test_client.delete(
-            f"/v1/conversations/{DUMMY_CONVERSATION_ID}"
-        )
+        response = test_client.delete(f"/v1/conversations/{DUMMY_CONVERSATION_ID}")
 
         assert response.status_code == 204, response.text
         checkpointer.adelete_thread.assert_awaited_once_with(DUMMY_CONVERSATION_ID)

--- a/mucgpt-core-service/tests/integration/test_chat_router.py
+++ b/mucgpt-core-service/tests/integration/test_chat_router.py
@@ -55,6 +55,16 @@ def stub_persistence(monkeypatch: pytest.MonkeyPatch) -> None:
             ]
         ),
     )
+    monkeypatch.setattr(
+        PersistanceHelpers,
+        "delete_conversation_mapping",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        PersistanceHelpers,
+        "get_checkpointer_if_ready",
+        Mock(return_value=Mock(adelete_thread=AsyncMock())),
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -231,6 +241,109 @@ class TestChatRouter:
         )
 
         assert response.status_code == 403
+
+    def test_delete_conversation(
+        self, test_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from core.persistance_helpers import PersistanceHelpers
+
+        mapping_mock = AsyncMock(return_value=True)
+        checkpointer = Mock(adelete_thread=AsyncMock())
+        monkeypatch.setattr(
+            PersistanceHelpers, "delete_conversation_mapping", mapping_mock
+        )
+        monkeypatch.setattr(
+            PersistanceHelpers,
+            "get_checkpointer_if_ready",
+            Mock(return_value=checkpointer),
+        )
+
+        response = test_client.delete(
+            f"/v1/conversations/{DUMMY_CONVERSATION_ID}"
+        )
+
+        assert response.status_code == 204, response.text
+        assert response.content == b""
+        mapping_mock.assert_awaited_once_with(DUMMY_CONVERSATION_ID, DUMMY_USER_ID)
+        checkpointer.adelete_thread.assert_awaited_once_with(DUMMY_CONVERSATION_ID)
+
+    def test_delete_conversation_forbidden(
+        self, test_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from core.persistance_helpers import PersistanceHelpers
+
+        monkeypatch.setattr(
+            PersistanceHelpers,
+            "is_user_in_conversation",
+            AsyncMock(return_value=False),
+        )
+
+        response = test_client.delete(
+            f"/v1/conversations/{DUMMY_CONVERSATION_ID}"
+        )
+
+        assert response.status_code == 403
+
+    def test_delete_conversation_not_found(
+        self, test_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from core.persistance_helpers import PersistanceHelpers
+
+        monkeypatch.setattr(
+            PersistanceHelpers,
+            "delete_conversation_mapping",
+            AsyncMock(return_value=False),
+        )
+
+        response = test_client.delete(
+            f"/v1/conversations/{DUMMY_CONVERSATION_ID}"
+        )
+
+        assert response.status_code == 404
+
+    def test_delete_conversation_persistence_not_ready(
+        self, test_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from core.persistance_helpers import PersistanceHelpers
+
+        monkeypatch.setattr(
+            PersistanceHelpers,
+            "get_checkpointer_if_ready",
+            Mock(return_value=None),
+        )
+
+        response = test_client.delete(
+            f"/v1/conversations/{DUMMY_CONVERSATION_ID}"
+        )
+
+        assert response.status_code == 500
+
+    def test_delete_conversation_checkpoint_failure_still_succeeds(
+        self, test_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed checkpoint delete only orphans rows; the request still succeeds."""
+        from core.persistance_helpers import PersistanceHelpers
+
+        checkpointer = Mock(
+            adelete_thread=AsyncMock(side_effect=RuntimeError("db down"))
+        )
+        monkeypatch.setattr(
+            PersistanceHelpers,
+            "delete_conversation_mapping",
+            AsyncMock(return_value=True),
+        )
+        monkeypatch.setattr(
+            PersistanceHelpers,
+            "get_checkpointer_if_ready",
+            Mock(return_value=checkpointer),
+        )
+
+        response = test_client.delete(
+            f"/v1/conversations/{DUMMY_CONVERSATION_ID}"
+        )
+
+        assert response.status_code == 204, response.text
+        checkpointer.adelete_thread.assert_awaited_once_with(DUMMY_CONVERSATION_ID)
 
     @patch("api.routers.chat_router.init_agent", new_callable=AsyncMock)
     def test_streaming_completion(self, mock_init_agent, test_client: TestClient):


### PR DESCRIPTION
## Summary
added new endpoint to chat router that enables chat deletions with persistant backend

## Why
chat deletion was not possible before

## Validation
How was this verified?
- [x] Automated tests
- [ ] Manual verification
- [ ] Not applicable

## UI Changes (If applicable)
*Please add screenshots or screencasts of any visual changes.*

## Change Areas
- [ ] Frontend
- [x] Core service
- [ ] Assistant service
- [ ] Migrations / DB
- [ ] Infrastructure / Docker / Compose / Keycloak
- [ ] CI / CD
- [ ] Docs

